### PR TITLE
Add TinyGSM task for seq2seq MDM training

### DIFF
--- a/docs/guide/adding-a-task.md
+++ b/docs/guide/adding-a-task.md
@@ -162,6 +162,10 @@ If your task needs packages beyond core xlm-core, document them in the task modu
 
 ---
 
+## Examples
+
+- [TinyGSM](../tasks/tinygsm.md) — large HF seq2seq task (question + code), Qwen tokenizer, FlexMDM / MLM / ARLM experiments.
+
 ## Quick reference table
 
 | Artifact | Location |

--- a/docs/guide/adding-a-task.md
+++ b/docs/guide/adding-a-task.md
@@ -57,6 +57,11 @@ Return only the columns your downstream collator and model need (drop raw text v
 - Code: {{ gh('src/xlm/tasks/math500/__init__.py', 'math500/__init__.py') }} (`math500_preprocess_fn`, `Math500Eval`)
 - Eval dataset: {{ gh('src/xlm/configs/lightning_train/datasets/math500_test.yaml', 'datasets/math500_test.yaml') }}
 
+**Code-execution eval (TinyGSM → GSM8K)** — same post-hoc pipeline, but scoring runs generated Python:
+
+- Code: {{ gh('src/xlm/tasks/tinygsm/gsm8k.py', 'tinygsm/gsm8k.py') }} (`gsm8k_preprocess_fn`, `Gsm8kCodeEval`)
+- Runbook: [TinyGSM / GSM8K](../tasks/tinygsm_gsm8k.md)
+
 **Large optional imports** — keep the default import surface light and defer heavy imports (see {{ gh('src/xlm/tasks/safe_molgen/__init__.py', 'safe_molgen/__init__.py') }} delegating to {{ gh('src/xlm/tasks/safe_molgen/_safe_molgen_impl.py', '_safe_molgen_impl.py') }}).
 
 For larger tasks you may instead split logic into additional modules inside `tasks/<your_task>/` and re-export public symbols from `__init__.py`; Hydra paths stay `xlm.tasks.<your_task>.<symbol>`.
@@ -164,7 +169,7 @@ If your task needs packages beyond core xlm-core, document them in the task modu
 
 ## Examples
 
-- [TinyGSM](../tasks/tinygsm.md) — large HF seq2seq task (question + code), Qwen tokenizer, FlexMDM / MLM / ARLM experiments.
+- [TinyGSM](../tasks/tinygsm.md) — large HF seq2seq task (question + code); model runbooks: [FlexMDM](../models/flexmdm.md#tinygsm), [MLM](../models/mlm.md#tinygsm), [ARLM](../models/arlm.md#tinygsm).
 
 ## Quick reference table
 

--- a/docs/models/arlm.md
+++ b/docs/models/arlm.md
@@ -99,7 +99,62 @@ All `*_update_fn(batch, loss_dict, tokenizer=None)`. Worked examples: {{ gh('tes
 Hydra groups under {{ gh_dir('xlm-models/arlm/configs', 'xlm-models/arlm/configs/') }}. Available experiment entry points:
 
 - `experiment=star_easy_arlm`
-- `experiment=tinygsm_arlm` (seq2seq; [TinyGSM task](../tasks/tinygsm.md))
+- `experiment=tinygsm_arlm` (seq2seq; [TinyGSM](#tinygsm))
+
+### TinyGSM
+
+Task dataset and preprocessing: [TinyGSM](../tasks/tinygsm.md). GSM8K and code-execution eval: [tinygsm_gsm8k.md](../tasks/tinygsm_gsm8k.md).
+
+| | |
+|---|---|
+| Experiment | `experiment=tinygsm_arlm` |
+| Datamodule | {{ gh('xlm-models/arlm/configs/datamodule/tinygsm_arlm.yaml', 'tinygsm_arlm') }} |
+| Experiment YAML | {{ gh('xlm-models/arlm/configs/experiment/tinygsm_arlm.yaml', 'tinygsm_arlm') }} |
+
+#### Training settings
+
+| Setting | Value |
+|---------|--------|
+| Tokenizer | Qwen2-0.5B (`Qwen/Qwen2-0.5B`) with added `<|mask|>` |
+| `block_size` | 512 |
+| `input_block_size` | 0 |
+| Batching | Per-device 32; global 512 |
+| Collators | STAR seq2seq (`seq2seq_*` / `seq2seq_pred_*`); no BOS between question and code |
+| Val / test prediction | Post-hoc `code_exec_accuracy` (`Gsm8kCodeEval`); token EM disabled |
+| Monitored metric | `val/lm/accumulated_loss` |
+| Training schedule | Up to 1M steps; validation every 50k steps; checkpoint every 2.5k steps (keep every 100k) |
+
+Collators are reused from existing STAR seq2seq configs; no TinyGSM-specific collator YAMLs.
+
+#### Commands
+
+**Prepare cache** (rank 0 before multi-GPU training):
+
+```bash
+xlm job_type=prepare_data experiment=tinygsm_arlm num_dataset_workers=8
+```
+
+Managers that share `full_name: TinyGSM/TinyGSM/train` use distinct manual cache
+directories via `filter_suffix` (e.g. `val_holdout`, `pred_preprocess`). After
+changing prediction preprocess, rebuild with
+`datamodule.rewrite_manual_cache=true` or delete the stale
+`.../TinyGSM/TinyGSM_pred_preprocess/train` tree if needed.
+
+On SLURM, see {{ gh('lib/slurm_scripts/submit_prepare_data.py', 'submit_prepare_data.py') }}.
+
+**Train** (DDP):
+
+```bash
+xlm job_name=tinygsm_arlm job_type=train experiment=tinygsm_arlm \
+  per_device_batch_size=32 trainer_strategy=ddp trainer.devices=8 trainer.num_nodes=1 \
+  ++trainer.precision=bf16-mixed compile=False
+```
+
+**Debug:** set `DEBUG_OVERFIT=1` to use `full_name_debug` (same HF split; short smoke runs).
+
+#### Experiment results
+
+Full W&B write-ups under `docs/experiments/` are deferred until runs exist. Use `experiment=tinygsm_arlm` with the [document experiment](../guide/eval.md) workflow when ready.
 
 ## 10. Testing
 

--- a/docs/models/arlm.md
+++ b/docs/models/arlm.md
@@ -99,6 +99,7 @@ All `*_update_fn(batch, loss_dict, tokenizer=None)`. Worked examples: {{ gh('tes
 Hydra groups under {{ gh_dir('xlm-models/arlm/configs', 'xlm-models/arlm/configs/') }}. Available experiment entry points:
 
 - `experiment=star_easy_arlm`
+- `experiment=tinygsm_arlm` (seq2seq; [TinyGSM task](../tasks/tinygsm.md))
 
 ## 10. Testing
 

--- a/docs/models/flexmdm.md
+++ b/docs/models/flexmdm.md
@@ -1,0 +1,81 @@
+# FlexMDM — Flexible Masked Diffusion Model
+
+## Overview
+
+`flexmdm` implements variable-length masked diffusion for text (linear insertion/unmasking noise, seq2seq and unconditional setups). Hydra configs live under {{ gh_dir('xlm-models/flexmdm/configs', 'xlm-models/flexmdm/configs/') }}.
+
+OWT-scale training and eval: [OWT FlexMDM experiment](../experiments/owt_flexmdm.md).
+
+## TinyGSM
+
+Task dataset and preprocessing: [TinyGSM](../tasks/tinygsm.md). GSM8K and code-execution eval: [tinygsm_gsm8k.md](../tasks/tinygsm_gsm8k.md).
+
+| | |
+|---|---|
+| Experiment | `experiment=tinygsm_flexmdm` |
+| Datamodule | {{ gh('xlm-models/flexmdm/configs/datamodule/tinygsm_flexmdm.yaml', 'tinygsm_flexmdm') }} |
+| Experiment YAML | {{ gh('xlm-models/flexmdm/configs/experiment/tinygsm_flexmdm.yaml', 'tinygsm_flexmdm') }} |
+
+Register a distinct pad token (`pad_token: "<|pad|>"` in `global_components.tokenizer.special_tokens`) so `pad_token_id != eos_token_id`; otherwise training and prediction will raise at init.
+
+### Training settings
+
+| Setting | Value |
+|---------|--------|
+| Tokenizer | Qwen2-0.5B (`Qwen/Qwen2-0.5B`) with added `<|mask|>` |
+| `block_size` | 512 |
+| `input_block_size` | 0 |
+| Batching | Per-device 32; global 512 |
+| Collators | STAR seq2seq (`seq2seq_*` / `seq2seq_pred_*`); no BOS between question and code |
+| Val / test prediction | Post-hoc `code_exec_accuracy` (`Gsm8kCodeEval`); token EM disabled |
+| Monitored metric | `val/lm/accumulated_loss` |
+| Training schedule | Up to 1M steps; validation every 50k steps; checkpoint every 2.5k steps (keep every 100k) |
+
+Collators are reused from existing STAR seq2seq configs; no TinyGSM-specific collator YAMLs.
+
+### Commands
+
+**Prepare cache** (rank 0 before multi-GPU training):
+
+```bash
+xlm job_type=prepare_data experiment=tinygsm_flexmdm num_dataset_workers=8
+```
+
+Managers that share `full_name: TinyGSM/TinyGSM/train` use distinct manual cache
+directories via `filter_suffix` (e.g. `val_holdout`, `pred_preprocess`). After
+changing prediction preprocess, rebuild with
+`datamodule.rewrite_manual_cache=true` or delete the stale
+`.../TinyGSM/TinyGSM_pred_preprocess/train` tree if needed.
+
+On SLURM, see {{ gh('lib/slurm_scripts/submit_prepare_data.py', 'submit_prepare_data.py') }}.
+
+**Train** (DDP):
+
+```bash
+xlm job_name=tinygsm_flexmdm job_type=train experiment=tinygsm_flexmdm \
+  per_device_batch_size=32 trainer_strategy=ddp trainer.devices=8 trainer.num_nodes=1 \
+  ++trainer.precision=bf16-mixed compile=False
+```
+
+### Debug overfit (one TinyGSM train example)
+
+Configs: {{ gh('xlm-models/flexmdm/configs/debug/overfit_tinygsm_flexmdm.yaml', 'debug/overfit_tinygsm_flexmdm') }}, {{ gh('xlm-models/flexmdm/configs/datasets/tinygsm_debug_one.yaml', 'datasets/tinygsm_debug_one') }}, {{ gh('xlm-models/flexmdm/configs/datasets/tinygsm_debug_one_pred.yaml', 'datasets/tinygsm_debug_one_pred') }}.
+
+Train and val/lm share one row (`filter_suffix: debug_one`); val/prediction uses prod `tinygsm_pred_preprocess_fn` on that row (`debug_one_pred`). Prefer this over generic `debug=overfit` for TinyGSM FlexMDM.
+
+**Prepare debug caches** (once; `num_dataset_workers=1` required for the first-row filter):
+
+```bash
+xlm job_type=prepare_data experiment=tinygsm_flexmdm debug=overfit_tinygsm_flexmdm \
+  datamodule.rewrite_manual_cache=true num_dataset_workers=1
+```
+
+**Debug train**:
+
+```bash
+xlm job_type=train experiment=tinygsm_flexmdm debug=overfit_tinygsm_flexmdm
+```
+
+### Experiment results
+
+Full W&B write-ups under `docs/experiments/` are deferred until runs exist. Use `experiment=tinygsm_flexmdm` with the [document experiment](../guide/eval.md) workflow when ready.

--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -39,6 +39,8 @@ flowchart LR
 | **Source package** | {{ gh_dir('xlm-models/arlm', 'xlm-models/arlm/') }} | {{ gh_dir('xlm-models/ilm', 'xlm-models/ilm/') }} | {{ gh_dir('xlm-models/mdlm', 'xlm-models/mdlm/') }} | {{ gh_dir('xlm-models/mlm', 'xlm-models/mlm/') }} |
 | **Per-family doc** | [arlm.md](arlm.md) | [ilm.md](ilm.md) | [mdlm.md](mdlm.md) | [mlm.md](mlm.md) |
 
+**FlexMDM** (variable-length masked diffusion; package {{ gh_dir('xlm-models/flexmdm', 'xlm-models/flexmdm/') }}) is documented separately in [flexmdm.md](flexmdm.md), including the [TinyGSM](flexmdm.md#tinygsm) seq2seq experiment.
+
 ## Page layout
 
 Every per-family page follows the same template:

--- a/docs/models/mlm.md
+++ b/docs/models/mlm.md
@@ -117,6 +117,7 @@ Hydra groups under {{ gh_dir('xlm-models/mlm/configs', 'xlm-models/mlm/configs/'
 - `experiment=sudoku_extreme_mlm`
 - `experiment=lm1b_mlm`
 - `experiment=owt_mlm`
+- `experiment=tinygsm_mlm` (seq2seq; [TinyGSM task](../tasks/tinygsm.md))
 - `experiment=owt_packed_mlm` (FlexAttention)
 - `experiment=uniref50_packed_mlm` (FlexAttention, protein)
 

--- a/docs/models/mlm.md
+++ b/docs/models/mlm.md
@@ -117,11 +117,66 @@ Hydra groups under {{ gh_dir('xlm-models/mlm/configs', 'xlm-models/mlm/configs/'
 - `experiment=sudoku_extreme_mlm`
 - `experiment=lm1b_mlm`
 - `experiment=owt_mlm`
-- `experiment=tinygsm_mlm` (seq2seq; [TinyGSM task](../tasks/tinygsm.md))
+- `experiment=tinygsm_mlm` (seq2seq; [TinyGSM](#tinygsm))
 - `experiment=owt_packed_mlm` (FlexAttention)
 - `experiment=uniref50_packed_mlm` (FlexAttention, protein)
 
 Recipes including packed-collator inspection (`debug=overfit`, `print_batch_fn=print_batch_mlm`) live in the package {{ gh('xlm-models/mlm/README.md', 'README') }}.
+
+### TinyGSM
+
+Task dataset and preprocessing: [TinyGSM](../tasks/tinygsm.md). GSM8K and code-execution eval: [tinygsm_gsm8k.md](../tasks/tinygsm_gsm8k.md).
+
+| | |
+|---|---|
+| Experiment | `experiment=tinygsm_mlm` |
+| Datamodule | {{ gh('xlm-models/mlm/configs/datamodule/tinygsm_mlm.yaml', 'tinygsm_mlm') }} |
+| Experiment YAML | {{ gh('xlm-models/mlm/configs/experiment/tinygsm_mlm.yaml', 'tinygsm_mlm') }} |
+
+#### Training settings
+
+| Setting | Value |
+|---------|--------|
+| Tokenizer | Qwen2-0.5B (`Qwen/Qwen2-0.5B`) with added `<|mask|>` |
+| `block_size` | 512 |
+| `input_block_size` | 0 |
+| Batching | Per-device 32; global 512 |
+| Collators | STAR seq2seq (`seq2seq_*` / `seq2seq_pred_*`); no BOS between question and code |
+| Val / test prediction | Post-hoc `code_exec_accuracy` (`Gsm8kCodeEval`); token EM disabled |
+| Monitored metric | `val/lm/accumulated_loss` |
+| Training schedule | Up to 1M steps; validation every 50k steps; checkpoint every 2.5k steps (keep every 100k) |
+
+Collators are reused from existing STAR seq2seq configs; no TinyGSM-specific collator YAMLs.
+
+#### Commands
+
+**Prepare cache** (rank 0 before multi-GPU training):
+
+```bash
+xlm job_type=prepare_data experiment=tinygsm_mlm num_dataset_workers=8
+```
+
+Managers that share `full_name: TinyGSM/TinyGSM/train` use distinct manual cache
+directories via `filter_suffix` (e.g. `val_holdout`, `pred_preprocess`). After
+changing prediction preprocess, rebuild with
+`datamodule.rewrite_manual_cache=true` or delete the stale
+`.../TinyGSM/TinyGSM_pred_preprocess/train` tree if needed.
+
+On SLURM, see {{ gh('lib/slurm_scripts/submit_prepare_data.py', 'submit_prepare_data.py') }}.
+
+**Train** (DDP):
+
+```bash
+xlm job_name=tinygsm_mlm job_type=train experiment=tinygsm_mlm \
+  per_device_batch_size=32 trainer_strategy=ddp trainer.devices=8 trainer.num_nodes=1 \
+  ++trainer.precision=bf16-mixed compile=False
+```
+
+**Debug:** set `DEBUG_OVERFIT=1` to use `full_name_debug` (same HF split; short smoke runs).
+
+#### Experiment results
+
+Full W&B write-ups under `docs/experiments/` are deferred until runs exist. Use `experiment=tinygsm_mlm` with the [document experiment](../guide/eval.md) workflow when ready.
 
 ## 10. Testing
 

--- a/docs/tasks/tinygsm.md
+++ b/docs/tasks/tinygsm.md
@@ -22,69 +22,18 @@ See also: [Adding a task or dataset](../guide/adding-a-task.md).
 | Base dataset | {{ gh('src/xlm/configs/lightning_train/datasets/tinygsm.yaml', 'datasets/tinygsm.yaml') }} |
 | Train | {{ gh('src/xlm/configs/lightning_train/datasets/tinygsm_train.yaml', 'datasets/tinygsm_train.yaml') }} |
 | Val (loss) | {{ gh('src/xlm/configs/lightning_train/datasets/tinygsm_val.yaml', 'datasets/tinygsm_val.yaml') }} |
-| Val (prediction) | {{ gh('src/xlm/configs/lightning_train/datasets/tinygsm_val_pred.yaml', 'datasets/tinygsm_val_pred.yaml') }} |
+| Val (prediction) | {{ gh('src/xlm/configs/lightning_train/datasets/tinygsm_val_pred.yaml', 'datasets/tinygsm_val_pred.yaml') }} — `tinygsm_pred_preprocess_fn`, code-exec post-hoc |
+| GSM8K test | {{ gh('src/xlm/configs/lightning_train/datasets/gsm8k_test_pred.yaml', 'datasets/gsm8k_test_pred.yaml') }} |
 | Datamodule skeleton | {{ gh('src/xlm/configs/lightning_train/datamodule/tinygsm.yaml', 'datamodule/tinygsm.yaml') }} |
+
+GSM8K and code-execution eval: [tinygsm_gsm8k.md](tinygsm_gsm8k.md).
 
 ## Model experiments
 
-| Model | Experiment | Datamodule |
-|-------|------------|------------|
-| FlexMDM | `experiment=tinygsm_flexmdm` | {{ gh('xlm-models/flexmdm/configs/datamodule/tinygsm_flexmdm.yaml', 'tinygsm_flexmdm') }} |
-| MLM | `experiment=tinygsm_mlm` | {{ gh('xlm-models/mlm/configs/datamodule/tinygsm_mlm.yaml', 'tinygsm_mlm') }} |
-| ARLM | `experiment=tinygsm_arlm` | {{ gh('xlm-models/arlm/configs/datamodule/tinygsm_arlm.yaml', 'tinygsm_arlm') }} |
+Training settings, prepare/train commands, and experiment YAMLs live in the per-model docs:
 
-Experiment YAMLs: {{ gh('xlm-models/flexmdm/configs/experiment/tinygsm_flexmdm.yaml', 'tinygsm_flexmdm') }}, {{ gh('xlm-models/mlm/configs/experiment/tinygsm_mlm.yaml', 'tinygsm_mlm') }}, {{ gh('xlm-models/arlm/configs/experiment/tinygsm_arlm.yaml', 'tinygsm_arlm') }}.
-
-### Shared training settings
-
-| Setting | Value |
-|---------|--------|
-| Tokenizer | Qwen2-0.5B (`Qwen/Qwen2-0.5B`) with added `<|mask|>` |
-| `block_size` | 512 |
-| `input_block_size` | 0 |
-| Batching | Per-device 32; global 512 |
-| Collators | STAR seq2seq (`seq2seq_*` / `seq2seq_pred_*`); no BOS between question and code |
-| Val prediction metrics | `exact_match`, `token_accuracy` (seq2seq model types) |
-| Training schedule | Up to 1M steps; validation every 50k steps; checkpoint every 2.5k steps (keep every 100k) |
-
-Collators are reused from existing STAR seq2seq configs; no TinyGSM-specific collator YAMLs.
-
-## Commands
-
-### Prepare cache
-
-Run on rank 0 before multi-GPU training (tokenizes and writes manual cache):
-
-```bash
-xlm job_type=prepare_data experiment=tinygsm_flexmdm num_dataset_workers=8
-# or: experiment=tinygsm_mlm / experiment=tinygsm_arlm
-```
-
-On SLURM, see {{ gh('lib/slurm_scripts/submit_prepare_data.py', 'submit_prepare_data.py') }}.
-
-### Train (OWT-scale DDP)
-
-```bash
-# FlexMDM
-xlm job_name=tinygsm_flexmdm job_type=train experiment=tinygsm_flexmdm \
-  per_device_batch_size=32 trainer_strategy=ddp trainer.devices=8 trainer.num_nodes=1 \
-  ++trainer.precision=bf16-mixed compile=False
-
-# MLM
-xlm job_name=tinygsm_mlm job_type=train experiment=tinygsm_mlm \
-  per_device_batch_size=32 trainer_strategy=ddp trainer.devices=8 trainer.num_nodes=1 \
-  ++trainer.precision=bf16-mixed compile=False
-
-# ARLM
-xlm job_name=tinygsm_arlm job_type=train experiment=tinygsm_arlm \
-  per_device_batch_size=32 trainer_strategy=ddp trainer.devices=8 trainer.num_nodes=1 \
-  ++trainer.precision=bf16-mixed compile=False
-```
-
-### Debug
-
-Set `DEBUG_OVERFIT=1` to use `full_name_debug` (same HF split; useful for short smoke runs).
-
-## Experiment result pages
-
-Full W&B training/eval write-ups under `docs/experiments/` are deferred until runs exist. Use the experiment names above with the [document experiment](../guide/eval.md) workflow when ready.
+| Model | Experiment | Doc |
+|-------|------------|-----|
+| FlexMDM | `experiment=tinygsm_flexmdm` | [FlexMDM — TinyGSM](../models/flexmdm.md#tinygsm) (debug: `debug=overfit_tinygsm_flexmdm`) |
+| MLM | `experiment=tinygsm_mlm` | [MLM — TinyGSM](../models/mlm.md#tinygsm) |
+| ARLM | `experiment=tinygsm_arlm` | [ARLM — TinyGSM](../models/arlm.md#tinygsm) |

--- a/docs/tasks/tinygsm.md
+++ b/docs/tasks/tinygsm.md
@@ -1,0 +1,90 @@
+# TinyGSM
+
+[TinyGSM/TinyGSM](https://huggingface.co/datasets/TinyGSM/TinyGSM) on Hugging Face provides roughly 11.8M training examples: math word problems (`question`) and Python solutions (`code`). In xlm-core each example is wired as a **seq2seq MDM** task: the prefix is `question + "\n"` and the suffix is `code`, following the field layout in [PUMA `tiny_gsm.py`](https://github.com/JaeyeonKim01/PUMA/blob/main/data/tiny_gsm.py).
+
+**Memmap pretokenization is not supported** (`labels.bin`, `prompt_mask.bin`, and related offline paths). Data flows only through `DatasetManager`, `job_type=prepare_data`, and iterable shards at train time.
+
+See also: [Adding a task or dataset](../guide/adding-a-task.md).
+
+## Preprocessing
+
+| Step | Detail |
+|------|--------|
+| Task module | {{ gh('src/xlm/tasks/tinygsm/__init__.py', 'xlm.tasks.tinygsm.tinygsm_preprocess_fn') }} |
+| Outputs | `prompt_token_ids` (question + separator), `input_token_ids` (code) |
+| On-the-fly processor | `xlm.datamodule.token_ids_to_input_ids_and_prompt_ids` |
+| Val split | 5% holdout via `train_test_split` with `seed: 2025`, `size: 0.05` on the HF `train` split |
+
+## Hydra configs (`src/xlm`)
+
+| Config | Path |
+|--------|------|
+| Base dataset | {{ gh('src/xlm/configs/lightning_train/datasets/tinygsm.yaml', 'datasets/tinygsm.yaml') }} |
+| Train | {{ gh('src/xlm/configs/lightning_train/datasets/tinygsm_train.yaml', 'datasets/tinygsm_train.yaml') }} |
+| Val (loss) | {{ gh('src/xlm/configs/lightning_train/datasets/tinygsm_val.yaml', 'datasets/tinygsm_val.yaml') }} |
+| Val (prediction) | {{ gh('src/xlm/configs/lightning_train/datasets/tinygsm_val_pred.yaml', 'datasets/tinygsm_val_pred.yaml') }} |
+| Datamodule skeleton | {{ gh('src/xlm/configs/lightning_train/datamodule/tinygsm.yaml', 'datamodule/tinygsm.yaml') }} |
+
+## Model experiments
+
+| Model | Experiment | Datamodule |
+|-------|------------|------------|
+| FlexMDM | `experiment=tinygsm_flexmdm` | {{ gh('xlm-models/flexmdm/configs/datamodule/tinygsm_flexmdm.yaml', 'tinygsm_flexmdm') }} |
+| MLM | `experiment=tinygsm_mlm` | {{ gh('xlm-models/mlm/configs/datamodule/tinygsm_mlm.yaml', 'tinygsm_mlm') }} |
+| ARLM | `experiment=tinygsm_arlm` | {{ gh('xlm-models/arlm/configs/datamodule/tinygsm_arlm.yaml', 'tinygsm_arlm') }} |
+
+Experiment YAMLs: {{ gh('xlm-models/flexmdm/configs/experiment/tinygsm_flexmdm.yaml', 'tinygsm_flexmdm') }}, {{ gh('xlm-models/mlm/configs/experiment/tinygsm_mlm.yaml', 'tinygsm_mlm') }}, {{ gh('xlm-models/arlm/configs/experiment/tinygsm_arlm.yaml', 'tinygsm_arlm') }}.
+
+### Shared training settings
+
+| Setting | Value |
+|---------|--------|
+| Tokenizer | Qwen2-0.5B (`Qwen/Qwen2-0.5B`) with added `<|mask|>` |
+| `block_size` | 512 |
+| `input_block_size` | 0 |
+| Batching | Per-device 32; global 512 |
+| Collators | STAR seq2seq (`seq2seq_*` / `seq2seq_pred_*`); no BOS between question and code |
+| Val prediction metrics | `exact_match`, `token_accuracy` (seq2seq model types) |
+| Training schedule | Up to 1M steps; validation every 50k steps; checkpoint every 2.5k steps (keep every 100k) |
+
+Collators are reused from existing STAR seq2seq configs; no TinyGSM-specific collator YAMLs.
+
+## Commands
+
+### Prepare cache
+
+Run on rank 0 before multi-GPU training (tokenizes and writes manual cache):
+
+```bash
+xlm job_type=prepare_data experiment=tinygsm_flexmdm num_dataset_workers=8
+# or: experiment=tinygsm_mlm / experiment=tinygsm_arlm
+```
+
+On SLURM, see {{ gh('lib/slurm_scripts/submit_prepare_data.py', 'submit_prepare_data.py') }}.
+
+### Train (OWT-scale DDP)
+
+```bash
+# FlexMDM
+xlm job_name=tinygsm_flexmdm job_type=train experiment=tinygsm_flexmdm \
+  per_device_batch_size=32 trainer_strategy=ddp trainer.devices=8 trainer.num_nodes=1 \
+  ++trainer.precision=bf16-mixed compile=False
+
+# MLM
+xlm job_name=tinygsm_mlm job_type=train experiment=tinygsm_mlm \
+  per_device_batch_size=32 trainer_strategy=ddp trainer.devices=8 trainer.num_nodes=1 \
+  ++trainer.precision=bf16-mixed compile=False
+
+# ARLM
+xlm job_name=tinygsm_arlm job_type=train experiment=tinygsm_arlm \
+  per_device_batch_size=32 trainer_strategy=ddp trainer.devices=8 trainer.num_nodes=1 \
+  ++trainer.precision=bf16-mixed compile=False
+```
+
+### Debug
+
+Set `DEBUG_OVERFIT=1` to use `full_name_debug` (same HF split; useful for short smoke runs).
+
+## Experiment result pages
+
+Full W&B training/eval write-ups under `docs/experiments/` are deferred until runs exist. Use the experiment names above with the [document experiment](../guide/eval.md) workflow when ready.

--- a/docs/tasks/tinygsm_gsm8k.md
+++ b/docs/tasks/tinygsm_gsm8k.md
@@ -1,0 +1,53 @@
+# TinyGSM training and GSM8K evaluation
+
+TinyGSM models are trained on `TinyGSM/TinyGSM` with question + Python code
+(seq2seq MDM). **Validation and test prediction** use code-execution accuracy
+(PUMA-style), not token exact match.
+
+## Code
+
+- Training preprocess: `xlm.tasks.tinygsm.tinygsm_preprocess_fn`
+- Val/test prediction preprocess: `xlm.tasks.tinygsm.tinygsm_pred_preprocess_fn`
+- GSM8K preprocess: `xlm.tasks.tinygsm.gsm8k_preprocess_fn`
+- Post-hoc eval: `xlm.tasks.tinygsm.Gsm8kCodeEval` (metric: `code_exec_accuracy`)
+
+Reference: [PUMA gsm8k_eval.py](https://github.com/JaeyeonKim01/PUMA/blob/main/eval/gsm8k_eval.py)
+
+## Val prediction (`val.prediction`)
+
+`tinygsm_val_pred` uses `tinygsm_pred_preprocess_fn`:
+
+- Prefix: question + `\n`
+- Suffix at inference: empty (model generates code)
+- `answer`: numeric gold from executing reference `code` once at preprocess time
+
+Post-hoc runs at validation epoch end → `val/code_exec_accuracy`.
+
+Prediction JSONL rows include:
+
+- `text` — full decoded sequence (question prefix + generated suffix)
+- `generated_text` — suffix only (`fixed==0` region); used by `Gsm8kCodeEval`
+
+## GSM8K test (`test.gsm8k_prediction`)
+
+`gsm8k_test_pred` uses `gsm8k_preprocess_fn` (numeric gold from `####` in the
+GSM8K `answer` field). Same `Gsm8kCodeEval` via dataloader name substring
+`prediction`.
+
+## Standalone GSM8K eval (FlexMDM)
+
+See also [FlexMDM — TinyGSM](../models/flexmdm.md#tinygsm) for training and checkpoint prep.
+
+```bash
+conda activate /scratch3/workspace/dhruveshpate_umass_edu-idlm/xlm-core/.venv_xlm_core
+cd /scratch3/workspace/dhruveshpate_umass_edu-idlm/xlm-core/xlm-models/flexmdm
+
+xlm job_type=eval job_name=tinygsm_gsm8k experiment=tinygsm_flexmdm_gsm8k_eval \
+  +eval.ckpt_path=/path/to/checkpoint.ckpt
+```
+
+## Unit tests
+
+```bash
+pytest tests/tasks/test_tinygsm_gsm8k.py
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
   - Models:
       - Overview: models/index.md
       - ARLM: models/arlm.md
+      - FlexMDM: models/flexmdm.md
       - ILM: models/ilm.md
       - MDLM: models/mdlm.md
       - MLM: models/mlm.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
 
   - Tasks:
       - OpenWebText: tasks/owt.md
+      - TinyGSM: tasks/tinygsm.md
 
   - Experiments:
       - OWT FlexMDM: experiments/owt_flexmdm.md

--- a/src/xlm/configs/lightning_train/datamodule/tinygsm.yaml
+++ b/src/xlm/configs/lightning_train/datamodule/tinygsm.yaml
@@ -1,0 +1,8 @@
+# @package _global_
+defaults:
+  - default
+  - /datasets@datamodule.dataset_managers.train.lm: tinygsm_train
+  - /datasets@datamodule.dataset_managers.val.lm: tinygsm_val
+
+tags:
+  dataset: tinygsm

--- a/src/xlm/configs/lightning_train/datasets/default_text.yaml
+++ b/src/xlm/configs/lightning_train/datasets/default_text.yaml
@@ -1,6 +1,6 @@
 _target_: xlm.datamodule.DatasetManager
 collator: ???
-full_name: ??? # like billion-word-benchmark/lm1b/train # <repo>/<ds_name>/<split_to_download> . 
+full_name: ??? # like billion-word-benchmark/lm1b/train # <repo>/<ds_name>/<split> or <repo>/<ds_name>/<config>/<split> 
 full_name_debug: ??? # like billion-word-benchmark/lm1b/train
 preprocess_function: ??? # likexlm.tasks.lm1b.preprocess_fn
 on_the_fly_processor: ??? # like xlm.datamodule.ids_to_example_fn or null

--- a/src/xlm/configs/lightning_train/datasets/gsm8k_test.yaml
+++ b/src/xlm/configs/lightning_train/datasets/gsm8k_test.yaml
@@ -1,0 +1,29 @@
+defaults:
+  - default_text
+
+_target_: xlm.datamodule.DatasetManager
+collator: ???
+full_name: openai/gsm8k/main/test
+full_name_debug: openai/gsm8k/main/test
+preprocess_function: xlm.tasks.tinygsm.gsm8k_preprocess_fn
+preprocess_function_kwargs:
+  sep: "\n"
+on_the_fly_processor: xlm.datamodule.token_ids_to_input_ids_and_prompt_ids
+on_the_fly_group_processor: null
+columns_to_remove:
+  - question
+stages:
+  - test
+iterable_dataset_shards: null
+shuffle_buffer_size: null
+shuffle_seed: 42
+split_by_node: false
+dataloader_kwargs:
+  batch_size: ${per_device_batch_size}
+  num_workers: ${num_dataloader_workers}
+  shuffle: false
+  pin_memory: True
+  persistent_workers: False
+  prefetch_factor: ${dataloader_prefetch_factor}
+  drop_last: false
+model_name: null

--- a/src/xlm/configs/lightning_train/datasets/gsm8k_test_pred.yaml
+++ b/src/xlm/configs/lightning_train/datasets/gsm8k_test_pred.yaml
@@ -1,0 +1,7 @@
+defaults:
+  - gsm8k_test
+
+stages:
+  - validate
+  - predict
+shuffle_buffer_size: null

--- a/src/xlm/configs/lightning_train/datasets/safe_fragment_test.yaml
+++ b/src/xlm/configs/lightning_train/datasets/safe_fragment_test.yaml
@@ -11,9 +11,7 @@ full_name_debug: ${oc.env:DATA_DIR,.}/${oc.select:molgen_task_name,motif_extensi
 preprocess_function: xlm.tasks.safe_molgen.genmol_fragment_preprocess_fn
 preprocess_function_kwargs:
     fragment_column: ${oc.select:molgen_task_name,motif_extension}
-on_the_fly_processor: xlm.datamodule.token_ids_to_input_ids_and_prompt_ids
-on_the_fly_processor_kwargs:
-    block_size: ${block_size}
+on_the_fly_processor: null
 on_the_fly_group_processor: xlm.datamodule.replicate_examples
 on_the_fly_group_processor_kwargs:
     num_samples: ${num_conditional_prediction_samples}
@@ -27,7 +25,7 @@ columns_to_remove:
 stages:
     - test
     - predict
-iterable_dataset_shards: null
+iterable_dataset_shards: 1
 shuffle_buffer_size: null
 shuffle_seed: 42
 split_by_node: true

--- a/src/xlm/configs/lightning_train/datasets/tinygsm.yaml
+++ b/src/xlm/configs/lightning_train/datasets/tinygsm.yaml
@@ -1,0 +1,30 @@
+defaults:
+  - default_text
+
+_target_: xlm.datamodule.DatasetManager
+collator: ???
+full_name: TinyGSM/TinyGSM/train
+full_name_debug: TinyGSM/TinyGSM/train
+preprocess_function: xlm.tasks.tinygsm.tinygsm_preprocess_fn
+preprocess_function_kwargs:
+  sep: "\n"
+on_the_fly_processor: xlm.datamodule.token_ids_to_input_ids_and_prompt_ids
+on_the_fly_group_processor: null
+columns_to_remove:
+  - question
+  - code
+stages:
+  - fit
+iterable_dataset_shards: 120
+shuffle_buffer_size: 10000
+shuffle_seed: 42
+split_by_node: true
+dataloader_kwargs:
+  batch_size: ${per_device_batch_size}
+  num_workers: ${num_dataloader_workers}
+  shuffle: null
+  pin_memory: True
+  persistent_workers: False
+  prefetch_factor: ${dataloader_prefetch_factor}
+  drop_last: True
+model_name: null

--- a/src/xlm/configs/lightning_train/datasets/tinygsm_test.yaml
+++ b/src/xlm/configs/lightning_train/datasets/tinygsm_test.yaml
@@ -1,0 +1,5 @@
+defaults:
+  - tinygsm_val
+
+stages:
+  - test

--- a/src/xlm/configs/lightning_train/datasets/tinygsm_test_pred.yaml
+++ b/src/xlm/configs/lightning_train/datasets/tinygsm_test_pred.yaml
@@ -1,0 +1,6 @@
+defaults:
+  - tinygsm_val_pred
+
+stages:
+  - test
+  - predict

--- a/src/xlm/configs/lightning_train/datasets/tinygsm_train.yaml
+++ b/src/xlm/configs/lightning_train/datasets/tinygsm_train.yaml
@@ -7,3 +7,4 @@ train_test_split:
   split: train
 stages:
   - fit
+make_infinite: true

--- a/src/xlm/configs/lightning_train/datasets/tinygsm_train.yaml
+++ b/src/xlm/configs/lightning_train/datasets/tinygsm_train.yaml
@@ -1,0 +1,9 @@
+defaults:
+  - tinygsm
+
+train_test_split:
+  size: 0.05
+  seed: 2025
+  split: train
+stages:
+  - fit

--- a/src/xlm/configs/lightning_train/datasets/tinygsm_val.yaml
+++ b/src/xlm/configs/lightning_train/datasets/tinygsm_val.yaml
@@ -1,10 +1,16 @@
 defaults:
   - tinygsm
 
+filter_suffix: val_holdout
 train_test_split:
   size: 0.05
   seed: 2025
   split: test
+# ``fit`` required so ``setup('fit')`` loads the dataset before in-training validation.
 stages:
+  - fit
   - validate
+iterable_dataset_shards: null
 shuffle_buffer_size: null
+dataloader_kwargs:
+  drop_last: false

--- a/src/xlm/configs/lightning_train/datasets/tinygsm_val.yaml
+++ b/src/xlm/configs/lightning_train/datasets/tinygsm_val.yaml
@@ -1,0 +1,10 @@
+defaults:
+  - tinygsm
+
+train_test_split:
+  size: 0.05
+  seed: 2025
+  split: test
+stages:
+  - validate
+shuffle_buffer_size: null

--- a/src/xlm/configs/lightning_train/datasets/tinygsm_val_pred.yaml
+++ b/src/xlm/configs/lightning_train/datasets/tinygsm_val_pred.yaml
@@ -1,0 +1,7 @@
+defaults:
+  - tinygsm_val
+
+stages:
+  - validate
+  - predict
+shuffle_buffer_size: null

--- a/src/xlm/configs/lightning_train/experiment/mauve.yaml
+++ b/src/xlm/configs/lightning_train/experiment/mauve.yaml
@@ -1,0 +1,3 @@
+# @package _global_
+defaults:
+  - /post_hoc_evaluator@post_hoc_evaluator.evaluators.prediction.mauve: mauve_text

--- a/src/xlm/configs/lightning_train/post_hoc_evaluator/fragment.yaml
+++ b/src/xlm/configs/lightning_train/post_hoc_evaluator/fragment.yaml
@@ -1,0 +1,5 @@
+_target_: xlm.tasks.safe_molgen.FragmentEval
+task_name: ${molgen_task_name}
+num_samples: ${num_conditional_prediction_samples}
+use_bracket_safe: ${oc.select:use_bracket_safe,true}
+compute_distance: true

--- a/src/xlm/datamodule.py
+++ b/src/xlm/datamodule.py
@@ -34,15 +34,16 @@ from datasets.distributed import split_dataset_by_node
 
 
 class _CycleDataset(IterableDataset):
-    """Thin PyTorch IterableDataset that cycles an HF IterableDataset forever.
+    """Fallback PyTorch IterableDataset that cycles an HF IterableDataset forever.
 
-    Used instead of HF's dataset.repeat(None) because that method wraps the
-    underlying iterable in RepeatExamplesIterable, which does not implement
-    num_shards. Both split_dataset_by_node and IterableDataset.__init__ call
-    _prepare_ex_iterable_for_iteration → num_shards, so neither split-then-
-    repeat nor repeat-then-split works with this version of the datasets
-    library. This wrapper operates at the Python/PyTorch level and bypasses
-    HF internals entirely.
+    Used on datasets < 4.0.0 instead of HF's IterableDataset.repeat(None),
+    which wraps the underlying iterable in RepeatExamplesIterable with a broken
+    shard_data_sources / num_shards protocol when combined with
+    split_dataset_by_node. On datasets >= 4.0.0, _make_dataset_infinite uses
+    repeat(None) instead. See https://github.com/dhruvdcoder/xlm-core/issues/39
+
+    Unlike HF's RepeatExamplesIterable, state_dict() deliberately returns {}
+    (no mid-cycle resume); epoch boundaries are encoded in max_steps instead.
     """
 
     def __init__(self, ds):
@@ -91,6 +92,14 @@ from xlm.utils.rank_zero import rank_zero_only
 from xlm.noise import NoiseSchedule
 from xlm.utils.rank_zero import RankedLogger
 import datasets
+from packaging.version import Version
+
+# RepeatExamplesIterable in datasets < 4.0.0 breaks split_dataset_by_node;
+# see https://github.com/dhruvdcoder/xlm-core/issues/39
+_DATASETS_SUPPORTS_NATIVE_REPEAT: bool = (
+    Version(datasets.__version__) >= Version("4.0.0")
+)
+
 from transformers import (
     PreTrainedTokenizer,
     PreTrainedTokenizerBase,
@@ -138,6 +147,25 @@ __all__ = [
 
 logger = RankedLogger(__name__, rank_zero_only=True)
 ranked_logger = RankedLogger(__name__, rank_zero_only=False)
+
+
+def _make_dataset_infinite(dataset):
+    """Wrap a per-rank iterable so training never hits StopIteration.
+
+    Uses HF IterableDataset.repeat(None) on datasets >= 4.0.0; falls back to
+    _CycleDataset on older pins. See https://github.com/dhruvdcoder/xlm-core/issues/39
+    """
+    if _DATASETS_SUPPORTS_NATIVE_REPEAT:
+        logger.info(
+            "make_infinite: using IterableDataset.repeat(None) "
+            f"(datasets {datasets.__version__})"
+        )
+        return dataset.repeat(None)
+    logger.info(
+        "make_infinite: using _CycleDataset fallback "
+        f"(datasets {datasets.__version__} < 4.0.0)"
+    )
+    return _CycleDataset(dataset)
 
 safe_imported = False
 try:
@@ -1270,7 +1298,7 @@ class DatasetManager:
                     self.dataset, rank=rank, world_size=world_size
                 )
                 if self.make_infinite:
-                    self.dataset = _CycleDataset(self.dataset)
+                    self.dataset = _make_dataset_infinite(self.dataset)
 
     def get_dataloader(
         self,

--- a/src/xlm/datamodule.py
+++ b/src/xlm/datamodule.py
@@ -2152,7 +2152,7 @@ class DefaultEmptyDataset(IterableDataset):
 
 
 def replicate_examples(
-    examples: Dict[str, List[List[int]]], tokenizer, num_samples: int
+    examples: Dict[str, List[List[int]]], tokenizer, num_samples: int, **kwargs
 ):
     """Repeat each example in the dictionary `num_samples` times such that the repeated examples are contiguous in the list."""
     examples_replicated = {}

--- a/src/xlm/datamodule.py
+++ b/src/xlm/datamodule.py
@@ -301,10 +301,21 @@ def load_auto_tokenizer(
         pretrained_model_name_or_path, trust_remote_code=True
     )
     if special_tokens is not None:
-        tokenizer.add_special_tokens(
-            {"additional_special_tokens": list(special_tokens.values())}
-        )
+        reserved: dict = {}
+        additional: list = []
         for token_name, token in special_tokens.items():
+            if token_name == "pad_token":
+                reserved["pad_token"] = token
+            else:
+                additional.append(token)
+        if additional:
+            tokenizer.add_special_tokens(
+                {"additional_special_tokens": additional}
+            )
+        if reserved:
+            tokenizer.add_special_tokens(reserved)
+        for token_name, token in special_tokens.items():
+            setattr(tokenizer, token_name, token)
             setattr(
                 tokenizer,
                 f"{token_name}_id",
@@ -735,6 +746,30 @@ def tokenizing_preprocess_fn(
 # region: Base DataModule
 
 
+def parse_hf_dataset_full_name(full_name: str) -> tuple[str, Optional[str], str]:
+    """Parse a Hugging Face dataset locator from ``full_name``.
+
+    Supported forms:
+
+    - ``repo/dataset/split`` → ``load_dataset(repo/dataset, split=split)``
+    - ``repo/dataset/config/split`` →
+      ``load_dataset(repo/dataset, config, split=split)`` (e.g. GSM8K ``main``)
+
+    Returns:
+        ``(hub_path, config_name, split)`` where ``config_name`` is ``None`` when
+        omitted.
+    """
+    parts = full_name.split("/")
+    if len(parts) == 3:
+        return "/".join(parts[:2]), None, parts[2]
+    if len(parts) == 4:
+        return "/".join(parts[:2]), parts[2], parts[3]
+    raise ValueError(
+        "full_name must be repo/dataset/split or repo/dataset/config/split; "
+        f"got {full_name!r} ({len(parts)} path segments)"
+    )
+
+
 class DatasetManager:
     """Manages a single dataset through its lifecycle: download, preprocess, cache, setup, and dataloader creation.
 
@@ -779,7 +814,8 @@ class DatasetManager:
 
         Args:
             collator: Collates examples into batches; model-specific.
-            full_name: Full dataset path (e.g., "repo/ds_name/split").
+            full_name: Hugging Face locator: ``repo/ds_name/split`` or
+                ``repo/ds_name/config/split`` (e.g. ``openai/gsm8k/main/test``).
             full_name_debug: Used when DEBUG_OVERFIT is True; typically the train
                 split path so val/test managers overfit on train data.
             dataloader_kwargs: batch_size, num_workers, shuffle, pin_memory.
@@ -809,7 +845,9 @@ class DatasetManager:
             use_manual_cache: If True, use manual cache dir created using save_to_disk(), else let HF Datasets do automatic caching.
             train_test_split: If set, split the loaded split into train/test via
                 ``Dataset.train_test_split``. Keys: ``size`` (float, passed as
-                ``test_size``) and optional ``seed`` (int, default 42).
+                ``test_size``) and optional ``seed`` (int, default 42). Skipped
+                when ``DEBUG_OVERFIT`` is true so train and val managers share
+                the same examples during debug overfit runs.
         """
         self.collator = collator
         self._full_name = full_name
@@ -824,14 +862,13 @@ class DatasetManager:
         # self.split_to_download = split_to_download
         self.dataloader_kwargs = dataloader_kwargs
         self.filter_fn = filter_fn
-        if filter_fn is not None:
-            if filter_suffix is None:
-                raise ValueError(
-                    "filter_suffix is required when filter_fn is provided"
-                )
-            self.filter_suffix = filter_suffix
-        else:
-            self.filter_suffix = None
+        if filter_fn is not None and filter_suffix is None:
+            raise ValueError(
+                "filter_suffix is required when filter_fn is provided"
+            )
+        # filter_suffix may be set without filter_fn to disambiguate manual cache
+        # paths (e.g. different preprocess_function on the same full_name).
+        self.filter_suffix = filter_suffix
         self.preprocess_function = preprocess_function
         self.preprocess_function_kwargs = preprocess_function_kwargs or {}
         self.preprocess_load_from_cache_file = preprocess_load_from_cache_file
@@ -886,11 +923,11 @@ class DatasetManager:
 
     @property
     def _split_to_download(self) -> str:
-        return self.full_name.split("/")[-1]
+        return parse_hf_dataset_full_name(self.full_name)[2]
 
     @property
     def name(self) -> str:
-        return "/".join(self.full_name.split("/")[:2])
+        return parse_hf_dataset_full_name(self.full_name)[0]
 
     # endregion: Properties
     ##################################################
@@ -899,20 +936,21 @@ class DatasetManager:
     # region: Private methods
 
     def _download(self, num_proc: Optional[int] = None) -> datasets.Dataset:
-        name = self.name
-        if name[0] == "/":
-            name = name[1:]
+        hub_path, config_name, split = parse_hf_dataset_full_name(self.full_name)
+        if hub_path[0] == "/":
+            hub_path = hub_path[1:]
         logger.info(f"Downloading {self.full_name}")
-        split_to_download = (
-            self._split_to_download if not self.train_test_split else "train"
-        )
-        ds = datasets.load_dataset(
-            name,
-            split=split_to_download,
-            num_proc=num_proc,
-            token=os.environ.get("HF_HUB_KEY"),
-        )
-        if self.train_test_split is not None:
+        split_to_download = split if not self.train_test_split else "train"
+        load_kwargs: Dict[str, Any] = {
+            "split": split_to_download,
+            "num_proc": num_proc,
+            "token": os.environ.get("HF_HUB_KEY"),
+        }
+        if config_name is None:
+            ds = datasets.load_dataset(hub_path, **load_kwargs)
+        else:
+            ds = datasets.load_dataset(hub_path, config_name, **load_kwargs)
+        if self.train_test_split is not None and not flags.DEBUG_OVERFIT:
             ds = ds.train_test_split(
                 test_size=self.train_test_split["size"],
                 seed=self.train_test_split["seed"],
@@ -969,9 +1007,13 @@ class DatasetManager:
         if self.filter_suffix is None:
             return Path(manual_cache_dir) / self.full_name
         else:
-            repo, ds_name, split = self.full_name.split("/")
+            hub_path, config_name, split = parse_hf_dataset_full_name(
+                self.full_name
+            )
+            repo, ds_name = hub_path.split("/", 1)
+            config_part = f"_{config_name}" if config_name else ""
             full_name_with_filter = (
-                f"{repo}/{ds_name}_{self.filter_suffix}/{split}"
+                f"{repo}/{ds_name}{config_part}_{self.filter_suffix}/{split}"
             )
             return Path(manual_cache_dir) / full_name_with_filter
 
@@ -1409,23 +1451,25 @@ class EvalDatasetManager:
 
     @property
     def _split_to_download(self) -> str:
-        return self.full_name.split("/")[-1]
+        return parse_hf_dataset_full_name(self.full_name)[2]
 
     @property
     def name(self) -> str:
-        return "/".join(self.full_name.split("/")[:2])
+        return parse_hf_dataset_full_name(self.full_name)[0]
 
     def _download(self, num_proc: Optional[int] = None) -> datasets.Dataset:
-        name = self.name
-        if name[0] == "/":
-            name = name[1:]
+        hub_path, config_name, split = parse_hf_dataset_full_name(self.full_name)
+        if hub_path[0] == "/":
+            hub_path = hub_path[1:]
         logger.info(f"Downloading {self.full_name}")
-        return datasets.load_dataset(
-            name,
-            split=self._split_to_download,
-            num_proc=num_proc,
-            token=os.environ.get("HF_HUB_KEY"),
-        )
+        load_kwargs: Dict[str, Any] = {
+            "split": self._split_to_download,
+            "num_proc": num_proc,
+            "token": os.environ.get("HF_HUB_KEY"),
+        }
+        if config_name is None:
+            return datasets.load_dataset(hub_path, **load_kwargs)
+        return datasets.load_dataset(hub_path, config_name, **load_kwargs)
 
     def _preprocess(
         self,

--- a/src/xlm/datamodule.py
+++ b/src/xlm/datamodule.py
@@ -845,9 +845,10 @@ class DatasetManager:
             use_manual_cache: If True, use manual cache dir created using save_to_disk(), else let HF Datasets do automatic caching.
             train_test_split: If set, split the loaded split into train/test via
                 ``Dataset.train_test_split``. Keys: ``size`` (float, passed as
-                ``test_size``) and optional ``seed`` (int, default 42). Skipped
-                when ``DEBUG_OVERFIT`` is true so train and val managers share
-                the same examples during debug overfit runs.
+                ``test_size``) and optional ``seed`` (int, default 42). Applied
+                when building manual caches. Holdout managers (``split: test``)
+                load the train-partition cache at runtime when ``DEBUG_OVERFIT``
+                is set (see :meth:`_get_load_cache_dir`).
         """
         self.collator = collator
         self._full_name = full_name
@@ -950,7 +951,7 @@ class DatasetManager:
             ds = datasets.load_dataset(hub_path, **load_kwargs)
         else:
             ds = datasets.load_dataset(hub_path, config_name, **load_kwargs)
-        if self.train_test_split is not None and not flags.DEBUG_OVERFIT:
+        if self.train_test_split is not None:
             ds = ds.train_test_split(
                 test_size=self.train_test_split["size"],
                 seed=self.train_test_split["seed"],
@@ -1017,6 +1018,22 @@ class DatasetManager:
             )
             return Path(manual_cache_dir) / full_name_with_filter
 
+    def _get_load_cache_dir(self, manual_cache_dir: str) -> Path:
+        """Manual cache path used when loading data in :meth:`setup`.
+
+        When ``DEBUG_OVERFIT`` is set, holdout managers (``train_test_split`` with
+        ``split: test``) read the train-partition cache (no ``filter_suffix``),
+        mirroring ``full_name_debug`` for datasets without ``train_test_split``.
+        Cache creation via :meth:`prepare_data` always uses :meth:`_get_cache_dir`.
+        """
+        if (
+            flags.DEBUG_OVERFIT
+            and self.train_test_split is not None
+            and self.train_test_split["split"] == "test"
+        ):
+            return Path(manual_cache_dir) / self.full_name
+        return self._get_cache_dir(manual_cache_dir)
+
     def _clean_manual_cache(self, manual_cache_dir: str) -> None:
         cache_dir = self._get_cache_dir(manual_cache_dir)
         logger.info(
@@ -1033,7 +1050,13 @@ class DatasetManager:
         ds.save_to_disk(cache_dir, num_shards=self.iterable_dataset_shards)
 
     def _load_from_cache(self, manual_cache_dir: str) -> datasets.Dataset:
-        cache_dir = self._get_cache_dir(manual_cache_dir)
+        cache_dir = self._get_load_cache_dir(manual_cache_dir)
+        write_dir = self._get_cache_dir(manual_cache_dir)
+        if cache_dir != write_dir:
+            logger.info(
+                f"DEBUG_OVERFIT: loading holdout manager from train-partition "
+                f"manual cache at {cache_dir} (write path remains {write_dir})"
+            )
         return datasets.load_from_disk(cache_dir)
 
     def _check_cache(self, manual_cache_dir: str) -> bool:

--- a/src/xlm/log_predictions.py
+++ b/src/xlm/log_predictions.py
@@ -393,6 +393,43 @@ class ConsolePredictionWriter(_PredictionWriter):
 class LogPredictions:
     """Main logging class that handles the shared pipeline and delegates to writers."""
 
+    def _append_writer(
+        self,
+        writer: Any,
+        fields_to_keep_in_output: Optional[List[str]],
+    ) -> None:
+        """Resolve one writers-list entry (shorthand, config dict, or instance)."""
+        if isinstance(writer, str):
+            if writer == "file":
+                self.writers.append(
+                    FilePredictionWriter(
+                        fields_to_keep_in_output=fields_to_keep_in_output
+                    )
+                )
+            elif writer == "logger":
+                self.writers.append(
+                    LoggerPredictionWriter(
+                        fields_to_keep_in_output=fields_to_keep_in_output
+                    )
+                )
+            elif writer == "console":
+                self.writers.append(
+                    ConsolePredictionWriter(
+                        fields_to_keep_in_output=fields_to_keep_in_output
+                    )
+                )
+            else:
+                raise ValueError(f"Invalid writer type: {writer}")
+        elif isinstance(writer, _PredictionWriter):
+            self.writers.append(writer)
+        elif isinstance(writer, (dict, ListConfig)):
+            self.writers.append(hydra.utils.instantiate(writer))
+        else:
+            raise ValueError(
+                "Each writer must be 'file' | 'logger' | 'console', a config "
+                f"dict with _target_, or a _PredictionWriter instance. Got: {type(writer)}"
+            )
+
     def __init__(
         self,
         writers: Optional[
@@ -413,31 +450,8 @@ class LogPredictions:
         """
         self.writers: List[_PredictionWriter] = []
         if isinstance(writers, (list, ListConfig)):
-            if isinstance(writers[0], str):
-                for writer_type in writers:
-                    if writer_type == "file":
-                        self.writers.append(
-                            FilePredictionWriter(
-                                fields_to_keep_in_output=fields_to_keep_in_output
-                            )
-                        )
-                    elif writer_type == "logger":
-                        self.writers.append(
-                            LoggerPredictionWriter(
-                                fields_to_keep_in_output=fields_to_keep_in_output
-                            )
-                        )
-                    elif writer_type == "console":
-                        self.writers.append(
-                            ConsolePredictionWriter(
-                                fields_to_keep_in_output=fields_to_keep_in_output
-                            )
-                        )
-                    else:
-                        raise ValueError(f"Invalid writer type: {writer_type}")
-            else:
-                for writer_config in writers:
-                    self.writers.append(hydra.utils.instantiate(writer_config))
+            for writer in writers:
+                self._append_writer(writer, fields_to_keep_in_output)
         elif writers is None:
             self.writers = []
             logger.warning(
@@ -445,8 +459,8 @@ class LogPredictions:
             )
         else:
             raise ValueError(
-                "writers must be a list of _PredictionWriter instances or string literals"
-                f"Got: {[type(w) for w in writers]}"
+                "writers must be a list of 'file' | 'logger' | 'console', Hydra "
+                f"config dicts, or _PredictionWriter instances. Got: {type(writers)}"
             )
         self.inject_target = inject_target
         self.additional_fields_from_batch = additional_fields_from_batch

--- a/src/xlm/log_predictions.py
+++ b/src/xlm/log_predictions.py
@@ -111,7 +111,7 @@ class FilePredictionWriter(_PredictionWriter):
         self,
         fields_to_keep_in_output: Optional[List[str]] = None,
         file_path_: Union[
-            Path, Literal["none", "from_pl_module"]
+            Path, str, Literal["none", "from_pl_module"]
         ] = "from_pl_module",
     ) -> None:
         """Initialize FilePredictionWriter.
@@ -121,10 +121,18 @@ class FilePredictionWriter(_PredictionWriter):
             file_path_: Path to the file or special values.
                 if "from_pl_module", query the pl_module for the predictions_file for the step and epoch
                 set to "none" to disable file writing
+                a str or Path is used as a fixed output file (appended across batches)
         """
         super().__init__(deepcopy(fields_to_keep_in_output))
 
-        self.file_path_ = file_path_
+        if file_path_ in ("from_pl_module", "none"):
+            self.file_path_: Union[Path, Literal["none", "from_pl_module"]] = (
+                file_path_
+            )
+        elif isinstance(file_path_, Path):
+            self.file_path_ = file_path_
+        else:
+            self.file_path_ = Path(str(file_path_))
         self.supports_reading = True
 
     def _get_file_path(
@@ -144,7 +152,7 @@ class FilePredictionWriter(_PredictionWriter):
         elif self.file_path_ == "none":
             return None
         elif isinstance(self.file_path_, Path):
-            file_path = Path(self.file_path_)
+            file_path = self.file_path_
         else:
             raise ValueError(f"Invalid file_path_: {self.file_path_}")
 

--- a/src/xlm/log_predictions.py
+++ b/src/xlm/log_predictions.py
@@ -422,13 +422,8 @@ class LogPredictions:
                 raise ValueError(f"Invalid writer type: {writer}")
         elif isinstance(writer, _PredictionWriter):
             self.writers.append(writer)
-        elif isinstance(writer, (dict, ListConfig)):
-            self.writers.append(hydra.utils.instantiate(writer))
         else:
-            raise ValueError(
-                "Each writer must be 'file' | 'logger' | 'console', a config "
-                f"dict with _target_, or a _PredictionWriter instance. Got: {type(writer)}"
-            )
+            self.writers.append(hydra.utils.instantiate(writer))
 
     def __init__(
         self,

--- a/src/xlm/tasks/safe_molgen/_safe_molgen_impl.py
+++ b/src/xlm/tasks/safe_molgen/_safe_molgen_impl.py
@@ -782,6 +782,8 @@ def genmol_fragment_preprocess_fn(
 
     example["prompt_token_ids"] = fragment_token_ids
     example["input_token_ids"] = target_token_ids
+    example["prompt_ids"] = fragment_token_ids
+    example["input_ids"] = target_token_ids
 
     return example
 

--- a/src/xlm/tasks/tinygsm/__init__.py
+++ b/src/xlm/tasks/tinygsm/__init__.py
@@ -1,0 +1,45 @@
+"""Preprocessing for TinyGSM/TinyGSM (math word problems + Python solutions).
+
+Field layout and train/val split semantics follow PUMA's tiny_gsm.py:
+https://github.com/JaeyeonKim01/PUMA/blob/main/data/tiny_gsm.py
+
+Each example is split into a prefix (question + separator) and a suffix (code)
+for seq2seq MDM training via ``prompt_token_ids`` / ``input_token_ids`` and an
+on-the-fly processor that maps to ``prompt_ids`` / ``input_ids``. Wire a
+seq2seq collator (e.g. ``MLMSeq2SeqTrainCollator``) in the model experiment.
+
+Memmap pretokenization (``pretokenize_tinygsm``, ``labels.bin``,
+``prompt_mask.bin``, ``TinyGSMDataset``) is not supported and will not be added.
+Data flows only through ``DatasetManager`` + ``prepare_data`` + iterable shards.
+
+Padding/truncation to a fixed block size is handled by the collator, not here.
+PUMA pads with EOS; xlm collators use ``pad_token_id`` unless the experiment
+sets ``loss_on_padding`` or pad=eos on the tokenizer.
+"""
+
+from typing import Any, Dict
+
+from transformers import PreTrainedTokenizerBase
+
+
+def tinygsm_preprocess_fn(
+    example: Dict[str, Any],
+    tokenizer: PreTrainedTokenizerBase,
+    *,
+    sep: str = "\n",
+) -> Dict[str, Any]:
+    """Tokenize TinyGSM rows into prefix/suffix token id lists.
+
+    Args:
+        example: HF row with ``question`` and ``code`` fields.
+        tokenizer: Hugging Face tokenizer (``encode``, no special tokens).
+        sep: String between question and code (PUMA default: newline).
+    """
+    question = (example.get("question") or "").strip()
+    code = (example.get("code") or "").strip()
+    sep_ids = tokenizer.encode(sep, add_special_tokens=False)
+    p_ids = tokenizer.encode(question, add_special_tokens=False)
+    a_ids = tokenizer.encode(code, add_special_tokens=False)
+    example["prompt_token_ids"] = p_ids + sep_ids
+    example["input_token_ids"] = a_ids
+    return example

--- a/src/xlm/tasks/tinygsm/__init__.py
+++ b/src/xlm/tasks/tinygsm/__init__.py
@@ -8,6 +8,9 @@ for seq2seq MDM training via ``prompt_token_ids`` / ``input_token_ids`` and an
 on-the-fly processor that maps to ``prompt_ids`` / ``input_ids``. Wire a
 seq2seq collator (e.g. ``MLMSeq2SeqTrainCollator``) in the model experiment.
 
+GSM8K test evaluation (code execution scoring) lives in :mod:`gsm8k` — see
+``gsm8k_preprocess_fn`` and ``Gsm8kCodeEval`` (PUMA gsm8k_eval.py).
+
 Memmap pretokenization (``pretokenize_tinygsm``, ``labels.bin``,
 ``prompt_mask.bin``, ``TinyGSMDataset``) is not supported and will not be added.
 Data flows only through ``DatasetManager`` + ``prepare_data`` + iterable shards.
@@ -20,6 +23,49 @@ sets ``loss_on_padding`` or pad=eos on the tokenizer.
 from typing import Any, Dict
 
 from transformers import PreTrainedTokenizerBase
+
+from xlm.tasks.tinygsm.gsm8k import (
+    Gsm8kCodeEval,
+    evaluate_samples,
+    extract_gsm8k_final_answer,
+    gold_answer_from_tinygsm_code,
+    gsm8k_preprocess_fn,
+    tinygsm_pred_preprocess_fn,
+)
+
+__all__ = [
+    "Gsm8kCodeEval",
+    "evaluate_samples",
+    "extract_gsm8k_final_answer",
+    "gold_answer_from_tinygsm_code",
+    "gsm8k_preprocess_fn",
+    "reset_tinygsm_debug_first_example_filter_fn",
+    "tinygsm_debug_first_example_filter_fn",
+    "tinygsm_pred_preprocess_fn",
+    "tinygsm_preprocess_fn",
+]
+
+_tinygsm_debug_first_example_kept = False
+
+
+def reset_tinygsm_debug_first_example_filter_fn() -> None:
+    """Reset :func:`tinygsm_debug_first_example_filter_fn` state (for tests)."""
+    global _tinygsm_debug_first_example_kept
+    _tinygsm_debug_first_example_kept = False
+
+
+def tinygsm_debug_first_example_filter_fn(example: Dict[str, Any]) -> bool:
+    """Keep only the first TinyGSM row when building debug manual caches.
+
+    Used with ``filter_suffix: debug_one`` in flexmdm debug dataset configs.
+    Run ``prepare_data`` with ``num_dataset_workers=1`` so ``Dataset.filter`` is
+    single-process; multiprocessing can drop or duplicate rows.
+    """
+    global _tinygsm_debug_first_example_kept
+    if _tinygsm_debug_first_example_kept:
+        return False
+    _tinygsm_debug_first_example_kept = True
+    return True
 
 
 def tinygsm_preprocess_fn(

--- a/src/xlm/tasks/tinygsm/gsm8k.py
+++ b/src/xlm/tasks/tinygsm/gsm8k.py
@@ -1,0 +1,364 @@
+"""GSM8K test evaluation for TinyGSM-trained code generators.
+
+Preprocessing mirrors TinyGSM seq2seq layout but uses GSM8K fields (``question``,
+``answer``) and leaves the suffix empty at inference. Scoring executes generated
+Python and compares numeric results, following PUMA's gsm8k_eval.py:
+https://github.com/JaeyeonKim01/PUMA/blob/main/eval/gsm8k_eval.py
+"""
+
+from __future__ import annotations
+
+import contextlib
+import math
+import re
+import signal
+import warnings
+from typing import Any, Dict, List, Optional, Tuple
+
+from transformers import PreTrainedTokenizerBase
+
+from xlm.utils.rank_zero import RankedLogger
+
+logger = RankedLogger(__name__, rank_zero_only=True)
+
+_ANS_RE = re.compile(r"####\s*([-+]?\d[\d,]*\.?\d*)")
+
+
+def extract_gsm8k_final_answer(ans_text: str) -> str:
+    """Extract the numeric final answer from a GSM8K ``answer`` field.
+
+    GSM8K answers end with ``#### 72``. Falls back to the last number in the
+    string if the marker is missing.
+    """
+    m = _ANS_RE.search(ans_text)
+    if not m:
+        nums = re.findall(r"[-+]?\d[\d,]*\.?\d*", ans_text)
+        return nums[-1].replace(",", "") if nums else ""
+    return m.group(1).replace(",", "")
+
+
+def gsm8k_preprocess_fn(
+    example: Dict[str, Any],
+    tokenizer: PreTrainedTokenizerBase,
+    *,
+    sep: str = "\n",
+) -> Dict[str, Any]:
+    """Tokenize GSM8K test rows for seq2seq MDM prediction.
+
+    Args:
+        example: HF row with ``question`` and ``answer`` fields.
+        tokenizer: Hugging Face tokenizer (``encode``, no special tokens).
+        sep: String between question and generated code region (PUMA default).
+
+    Returns:
+        Updated example with ``prompt_token_ids``, empty ``input_token_ids``,
+        and ``answer`` set to the numeric gold string.
+    """
+    question = (example.get("question") or "").strip()
+    raw_answer = example.get("answer") or ""
+    gold = extract_gsm8k_final_answer(raw_answer)
+    sep_ids = tokenizer.encode(sep, add_special_tokens=False)
+    p_ids = tokenizer.encode(question, add_special_tokens=False)
+    example["prompt_token_ids"] = p_ids + sep_ids
+    example["input_token_ids"] = []
+    example["answer"] = gold
+    return example
+
+
+def execute_tinygsm_code(
+    code: str, timeout_s: float = 1.0
+) -> Optional[int | float]:
+    """Run reference TinyGSM ``code`` and return ``simple_math_problem()`` value."""
+    extracted = _extract_code(code)
+    try:
+        with _time_limit(timeout_s):
+            ns = _safe_exec_no_timer(extracted)
+            fn = ns.get("simple_math_problem", None)
+            if fn is None:
+                return None
+            return _to_number(fn())
+    except (_Timeout, Exception):
+        return None
+
+
+def gold_answer_from_tinygsm_code(code: str, timeout_s: float = 1.0) -> str:
+    """Numeric gold string for post-hoc eval (empty if reference code fails)."""
+    val = execute_tinygsm_code(code, timeout_s=timeout_s)
+    if val is None:
+        return ""
+    if isinstance(val, int):
+        return str(val)
+    return str(val)
+
+
+def tinygsm_pred_preprocess_fn(
+    example: Dict[str, Any],
+    tokenizer: PreTrainedTokenizerBase,
+    *,
+    sep: str = "\n",
+    gold_timeout_s: float = 1.0,
+) -> Dict[str, Any]:
+    """TinyGSM rows for seq2seq prediction: question prefix, empty suffix, numeric gold.
+
+    Gold is computed once by executing the reference ``code`` (PUMA/TinyGSM convention).
+    """
+    question = (example.get("question") or "").strip()
+    code = (example.get("code") or "").strip()
+    gold = gold_answer_from_tinygsm_code(code, timeout_s=gold_timeout_s)
+    sep_ids = tokenizer.encode(sep, add_special_tokens=False)
+    p_ids = tokenizer.encode(question, add_special_tokens=False)
+    example["prompt_token_ids"] = p_ids + sep_ids
+    example["input_token_ids"] = []
+    example["answer"] = gold
+    return example
+
+
+# ---------------------------------------------------------------------------
+# Code execution scoring (ported from PUMA gsm8k_eval.py)
+# ---------------------------------------------------------------------------
+
+
+class _Timeout(Exception):
+    pass
+
+
+def _timeout_handler(signum, frame) -> None:
+    raise _Timeout()
+
+
+@contextlib.contextmanager
+def _time_limit(timeout_s: float):
+    """Hard wall-clock limit via SIGALRM (POSIX main thread only)."""
+    has_alarm = hasattr(signal, "SIGALRM") and hasattr(signal, "setitimer")
+    old_handler = None
+    if has_alarm:
+        old_handler = signal.signal(signal.SIGALRM, _timeout_handler)
+        signal.setitimer(signal.ITIMER_REAL, timeout_s)
+    try:
+        yield
+    finally:
+        if has_alarm:
+            signal.setitimer(signal.ITIMER_REAL, 0)
+            signal.signal(signal.SIGALRM, old_handler)
+
+
+def _safe_exec_no_timer(code: str) -> Dict[str, Any]:
+    """Execute code in a restricted namespace (no timeout; wrap with _time_limit)."""
+    import math as _math
+
+    safe_builtins = {
+        "abs": abs,
+        "min": min,
+        "max": max,
+        "sum": sum,
+        "len": len,
+        "range": range,
+        "enumerate": enumerate,
+        "int": int,
+        "float": float,
+        "str": str,
+        "bool": bool,
+        "round": round,
+        "print": lambda *args, **kwargs: None,
+    }
+
+    def _limited_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "math":
+            return __import__(name, globals, locals, fromlist, level)
+        raise ImportError(f"Import blocked: {name}")
+
+    safe_builtins["__import__"] = _limited_import
+
+    ns: Dict[str, Any] = {
+        "__builtins__": safe_builtins,
+        "math": _math,
+    }
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", SyntaxWarning)
+        exec(code, ns, ns)
+
+    return ns
+
+
+def _extract_code(text: str) -> str:
+    """Heuristically extract executable Python from model output."""
+    for stopper in ["<|endoftext|>", "<|eot_id|>", "</s>"]:
+        if stopper in text:
+            text = text.split(stopper, 1)[0]
+
+    fence = re.search(
+        r"```(?:python)?\s*(.*?)```", text, flags=re.DOTALL | re.IGNORECASE
+    )
+    if fence:
+        text = fence.group(1)
+
+    i = text.find("def ")
+    if i != -1:
+        text = text[i:]
+
+    text = text.strip()
+
+    lines = text.splitlines()
+    for k in range(0, min(50, len(lines))):
+        candidate = "\n".join(lines[: len(lines) - k]).strip()
+        if not candidate:
+            continue
+        try:
+            compile(candidate, "<sample>", "exec")
+            return candidate
+        except SyntaxError:
+            continue
+
+    return text
+
+
+def _numbers_equal(pred, gold) -> bool:
+    if pred is None or gold is None:
+        return False
+    if isinstance(pred, float) or isinstance(gold, float):
+        return abs(float(pred) - float(gold)) <= 1e-3
+    return int(pred) == int(gold)
+
+
+def _to_number(x) -> Optional[int | float]:
+    """Normalize return values to int or float where possible."""
+    if x is None:
+        return None
+    if isinstance(x, int):
+        return int(x)
+    if isinstance(x, float):
+        if not math.isfinite(float(x)):
+            return None
+        xf = float(x)
+        if abs(xf - round(xf)) < 1e-6:
+            return int(round(xf))
+        return xf
+    if isinstance(x, str):
+        m = re.search(r"[-+]?\d[\d,]*\.?\d*", x)
+        if not m:
+            return None
+        s = m.group(0).replace(",", "")
+        if s.count(".") == 1:
+            f = float(s)
+            if abs(f - round(f)) < 1e-6:
+                return int(round(f))
+            return f
+        return int(s)
+    return None
+
+
+def evaluate_samples(sample: str, answer: str, timeout_s: float = 1.0) -> bool:
+    """Return True if executing ``sample`` yields the gold numeric ``answer``."""
+    code = _extract_code(sample)
+
+    try:
+        with _time_limit(timeout_s):
+            ns = _safe_exec_no_timer(code)
+            fn = ns.get("simple_math_problem", None)
+            if fn is None:
+                return False
+            out = fn()
+    except (_Timeout, Exception):
+        return False
+
+    pred = _to_number(out)
+    gold = _to_number(answer)
+    return _numbers_equal(pred, gold)
+
+
+def prediction_code_text(pred: Dict[str, Any]) -> str:
+    """Return model output text to execute for code-exec scoring.
+
+    Prefers ``generated_text`` (suffix-only decode from FlexMDM). Falls back to
+    ``text`` (full sequence including the question prefix) for older logs.
+    """
+    generated = pred.get("generated_text")
+    if generated is not None and str(generated).strip():
+        return str(generated)
+    return str(pred.get("text", ""))
+
+
+def evaluate_sample_with_details(
+    sample: str, answer: str, timeout_s: float = 1.0
+) -> Tuple[bool, Optional[int | float], Optional[str]]:
+    """Like ``evaluate_samples`` but returns (correct, pred_value, error)."""
+    code = _extract_code(sample)
+
+    try:
+        with _time_limit(timeout_s):
+            ns = _safe_exec_no_timer(code)
+            fn = ns.get("simple_math_problem", None)
+            if fn is None:
+                return False, None, "simple_math_problem not defined"
+            out = fn()
+    except _Timeout:
+        return False, None, "timeout"
+    except Exception as e:
+        return False, None, repr(e)
+
+    pred = _to_number(out)
+    gold = _to_number(answer)
+    return _numbers_equal(pred, gold), pred, None
+
+
+class Gsm8kCodeEval:
+    """Post-hoc evaluator: execute generated code and compare to GSM8K gold.
+
+    Expects prediction rows with ``generated_text`` (suffix-only decode; preferred)
+    or ``text`` (full sequence), plus ``answer`` or ``truth`` (numeric gold).
+
+    Hydra::
+
+        post_hoc_evaluator:
+          _target_: xlm.tasks.tinygsm.Gsm8kCodeEval
+    """
+
+    def __init__(self, timeout_s: float = 1.0) -> None:
+        self.timeout_s = timeout_s
+
+    def eval(
+        self,
+        predictions: List[Dict[str, Any]],
+        tokenizer: Any = None,
+        **kwargs: Any,
+    ) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+        if not predictions:
+            return predictions, {}
+
+        n_correct = 0
+        n_exec_failures = 0
+
+        for pred in predictions:
+            raw_text = prediction_code_text(pred)
+            gold_text = pred.get("answer", "") or pred.get("truth", "")
+
+            correct, pred_value, err = evaluate_sample_with_details(
+                raw_text, str(gold_text), timeout_s=self.timeout_s
+            )
+            pred["correct"] = correct
+            pred["pred_value"] = pred_value
+            if err is not None:
+                pred["exec_error"] = err
+                n_exec_failures += 1
+
+            n_correct += int(correct)
+
+        total = len(predictions)
+        accuracy = n_correct / total
+
+        logger.info(
+            "Gsm8kCodeEval: %d/%d correct (%.2f%%) | exec failures: %d",
+            n_correct,
+            total,
+            accuracy * 100,
+            n_exec_failures,
+        )
+
+        aggregated_metrics = {
+            "code_exec_accuracy": accuracy,
+            "n_correct": n_correct,
+            "n_total": total,
+            "n_exec_failures": n_exec_failures,
+        }
+        return predictions, aggregated_metrics

--- a/tests/core/test_datamodule.py
+++ b/tests/core/test_datamodule.py
@@ -28,6 +28,8 @@ import datasets
 import pytest
 import torch
 from torch.utils.data import DataLoader
+
+import xlm.flags as flags
 from torchdata.stateful_dataloader import StatefulDataLoader
 
 from tests.datamodule_helpers import EXAMPLE_TOKEN_LEN
@@ -267,6 +269,37 @@ class TestPrepareData:
         )
         assert 0 < len(ds) < TRAIN_SIZE
         assert len(ds) + len(other) == TRAIN_SIZE
+
+    def test_train_test_split_skipped_under_debug_overfit(
+        self,
+        dataset_manager_factory,
+        simple_tokenizer,
+        manual_cache_dir,
+    ):
+        original = flags.DEBUG_OVERFIT
+        flags.DEBUG_OVERFIT = True
+        try:
+            dsm_train = dataset_manager_factory(
+                use_manual_cache=False,
+                train_test_split={"size": 0.4, "seed": 0, "split": "train"},
+            )
+            dsm_val = dataset_manager_factory(
+                use_manual_cache=False,
+                train_test_split={"size": 0.4, "seed": 0, "split": "test"},
+            )
+            train_ds = dsm_train.prepare_data(
+                manual_cache_dir=str(manual_cache_dir),
+                tokenizer=simple_tokenizer,
+            )
+            val_ds = dsm_val.prepare_data(
+                manual_cache_dir=str(manual_cache_dir),
+                tokenizer=simple_tokenizer,
+            )
+            assert train_ds is not None and val_ds is not None
+            assert len(train_ds) == TRAIN_SIZE
+            assert len(val_ds) == TRAIN_SIZE
+        finally:
+            flags.DEBUG_OVERFIT = original
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_datamodule.py
+++ b/tests/core/test_datamodule.py
@@ -270,34 +270,29 @@ class TestPrepareData:
         assert 0 < len(ds) < TRAIN_SIZE
         assert len(ds) + len(other) == TRAIN_SIZE
 
-    def test_train_test_split_skipped_under_debug_overfit(
+    def test_debug_overfit_holdout_loads_train_cache_path(
         self,
         dataset_manager_factory,
-        simple_tokenizer,
         manual_cache_dir,
     ):
         original = flags.DEBUG_OVERFIT
         flags.DEBUG_OVERFIT = True
         try:
             dsm_train = dataset_manager_factory(
-                use_manual_cache=False,
                 train_test_split={"size": 0.4, "seed": 0, "split": "train"},
             )
             dsm_val = dataset_manager_factory(
-                use_manual_cache=False,
                 train_test_split={"size": 0.4, "seed": 0, "split": "test"},
+                filter_suffix="val_holdout",
             )
-            train_ds = dsm_train.prepare_data(
-                manual_cache_dir=str(manual_cache_dir),
-                tokenizer=simple_tokenizer,
+            cache_root = str(manual_cache_dir)
+            assert dsm_train._get_load_cache_dir(
+                cache_root
+            ) == dsm_val._get_load_cache_dir(cache_root)
+            assert dsm_train._get_cache_dir(cache_root) == dsm_val._get_load_cache_dir(
+                cache_root
             )
-            val_ds = dsm_val.prepare_data(
-                manual_cache_dir=str(manual_cache_dir),
-                tokenizer=simple_tokenizer,
-            )
-            assert train_ds is not None and val_ds is not None
-            assert len(train_ds) == TRAIN_SIZE
-            assert len(val_ds) == TRAIN_SIZE
+            assert "val_holdout" in str(dsm_val._get_cache_dir(cache_root))
         finally:
             flags.DEBUG_OVERFIT = original
 

--- a/tests/core/test_datamodule.py
+++ b/tests/core/test_datamodule.py
@@ -27,13 +27,19 @@ from pathlib import Path
 import datasets
 import pytest
 import torch
+from datasets.distributed import split_dataset_by_node
+from packaging.version import Version
 from torch.utils.data import DataLoader
 
 import xlm.flags as flags
 from torchdata.stateful_dataloader import StatefulDataLoader
 
 from tests.datamodule_helpers import EXAMPLE_TOKEN_LEN
-from xlm.datamodule import DatasetManager
+from xlm.datamodule import (
+    DatasetManager,
+    _CycleDataset,
+    _make_dataset_infinite,
+)
 
 
 # Convenience constants that reflect the in-memory registry contents in
@@ -510,6 +516,110 @@ class TestSetup:
             world_size=1,
         )
         assert dsm.dataset is first
+
+
+# ---------------------------------------------------------------------------
+# make_infinite version gate
+# ---------------------------------------------------------------------------
+
+
+def _setup_make_infinite_ddp(
+    dataset_manager_factory,
+    simple_tokenizer,
+    manual_cache_dir: Path,
+) -> DatasetManager:
+    dsm = dataset_manager_factory(
+        use_manual_cache=False,
+        iterable_dataset_shards=4,
+        make_infinite=True,
+    )
+    dsm.setup(
+        stage="fit",
+        manual_cache_dir=str(manual_cache_dir),
+        tokenizer=simple_tokenizer,
+        block_size=EXAMPLE_TOKEN_LEN,
+        is_ddp=True,
+        rank=0,
+        world_size=2,
+    )
+    return dsm
+
+
+class TestMakeInfiniteVersionGate:
+    """Version-gated native repeat vs _CycleDataset fallback."""
+
+    def test_make_infinite_applies_cycle_dataset_on_lt_4(
+        self, dataset_manager_factory, simple_tokenizer, manual_cache_dir
+    ):
+        if Version(datasets.__version__) >= Version("4.0.0"):
+            pytest.skip("requires datasets < 4.0.0")
+        dsm = _setup_make_infinite_ddp(
+            dataset_manager_factory, simple_tokenizer, manual_cache_dir
+        )
+        assert isinstance(dsm.dataset, _CycleDataset)
+
+    def test_make_infinite_applies_native_repeat_on_gte_4(
+        self, dataset_manager_factory, simple_tokenizer, manual_cache_dir
+    ):
+        if Version(datasets.__version__) < Version("4.0.0"):
+            pytest.skip("requires datasets >= 4.0.0")
+        dsm = _setup_make_infinite_ddp(
+            dataset_manager_factory, simple_tokenizer, manual_cache_dir
+        )
+        assert not isinstance(dsm.dataset, _CycleDataset)
+        it = iter(dsm.dataset)
+        for _ in range(3):
+            next(it)
+
+    def test_make_infinite_helper_respects_monkeypatch(self, monkeypatch):
+        class FakeDataset:
+            def __init__(self):
+                self.repeat_called = False
+
+            def repeat(self, n):
+                self.repeat_called = True
+                assert n is None
+                return self
+
+        fake = FakeDataset()
+        monkeypatch.setattr(
+            "xlm.datamodule._DATASETS_SUPPORTS_NATIVE_REPEAT", True
+        )
+        result = _make_dataset_infinite(fake)
+        assert fake.repeat_called
+        assert result is fake
+
+        class PlainDataset:
+            pass
+
+        plain = PlainDataset()
+        monkeypatch.setattr(
+            "xlm.datamodule._DATASETS_SUPPORTS_NATIVE_REPEAT", False
+        )
+        wrapped = _make_dataset_infinite(plain)
+        assert isinstance(wrapped, _CycleDataset)
+        assert wrapped._ds is plain
+
+
+class TestRepeatAfterSplitDatasetByNode:
+    """Regression for https://github.com/dhruvdcoder/xlm-core/issues/39."""
+
+    def test_repeat_none_after_split_does_not_raise_on_gte_4(self):
+        if Version(datasets.__version__) < Version("4.0.0"):
+            pytest.skip(
+                "RepeatExamplesIterable shard_data_sources bug; "
+                "see https://github.com/dhruvdcoder/xlm-core/issues/39"
+            )
+
+        def gen():
+            for i in range(8):
+                yield {"x": i}
+
+        ds = datasets.Dataset.from_generator(gen).to_iterable_dataset(
+            num_shards=4
+        )
+        ds = split_dataset_by_node(ds.repeat(None), rank=0, world_size=2)
+        next(iter(ds))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_parse_hf_dataset_full_name.py
+++ b/tests/core/test_parse_hf_dataset_full_name.py
@@ -1,0 +1,74 @@
+"""Tests for Hugging Face ``full_name`` parsing in :mod:`xlm.datamodule`."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from xlm.datamodule import DatasetManager, parse_hf_dataset_full_name
+
+
+def test_parse_three_part_full_name() -> None:
+    assert parse_hf_dataset_full_name("openai/gsm8k/test") == (
+        "openai/gsm8k",
+        None,
+        "test",
+    )
+
+
+def test_parse_four_part_full_name_with_config() -> None:
+    assert parse_hf_dataset_full_name("openai/gsm8k/main/test") == (
+        "openai/gsm8k",
+        "main",
+        "test",
+    )
+
+
+def test_parse_invalid_full_name_raises() -> None:
+    with pytest.raises(ValueError, match="repo/dataset/split"):
+        parse_hf_dataset_full_name("only/two")
+
+
+def _minimal_dataset_manager(
+    simple_collator, full_name: str
+) -> DatasetManager:
+    return DatasetManager(
+        collator=simple_collator,
+        full_name=full_name,
+        full_name_debug=full_name,
+        dataloader_kwargs={
+            "batch_size": 2,
+            "num_workers": 0,
+            "pin_memory": False,
+        },
+    )
+
+
+def test_dataset_manager_download_passes_config_name(simple_collator) -> None:
+    dsm = _minimal_dataset_manager(
+        simple_collator, full_name="openai/gsm8k/main/test"
+    )
+    fake_ds = MagicMock()
+    with patch("xlm.datamodule.datasets.load_dataset", return_value=fake_ds) as load:
+        dsm._download()
+    load.assert_called_once_with(
+        "openai/gsm8k",
+        "main",
+        split="test",
+        num_proc=None,
+        token=None,
+    )
+
+
+def test_dataset_manager_download_three_part_unchanged(simple_collator) -> None:
+    dsm = _minimal_dataset_manager(simple_collator, full_name="mem/raw/test")
+    fake_ds = MagicMock()
+    with patch("xlm.datamodule.datasets.load_dataset", return_value=fake_ds) as load:
+        dsm._download()
+    load.assert_called_once_with(
+        "mem/raw",
+        split="test",
+        num_proc=None,
+        token=None,
+    )

--- a/tests/datamodule_helpers.py
+++ b/tests/datamodule_helpers.py
@@ -43,8 +43,6 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence
 import datasets
 import torch
 
-import xlm.flags as flags
-
 
 # ---------------------------------------------------------------------------
 # In-memory datasets registry
@@ -206,7 +204,7 @@ def make_patched_download(
                 f"Available: {sorted(registry)}"
             )
 
-        if self.train_test_split is not None and not flags.DEBUG_OVERFIT:
+        if self.train_test_split is not None:
             ds = ds.train_test_split(
                 test_size=self.train_test_split["size"],
                 seed=self.train_test_split["seed"],

--- a/tests/datamodule_helpers.py
+++ b/tests/datamodule_helpers.py
@@ -43,6 +43,8 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence
 import datasets
 import torch
 
+import xlm.flags as flags
+
 
 # ---------------------------------------------------------------------------
 # In-memory datasets registry
@@ -204,7 +206,7 @@ def make_patched_download(
                 f"Available: {sorted(registry)}"
             )
 
-        if self.train_test_split is not None:
+        if self.train_test_split is not None and not flags.DEBUG_OVERFIT:
             ds = ds.train_test_split(
                 test_size=self.train_test_split["size"],
                 seed=self.train_test_split["seed"],

--- a/tests/models/flexmdm/test_loss_not_eos.py
+++ b/tests/models/flexmdm/test_loss_not_eos.py
@@ -1,0 +1,37 @@
+"""Tests that get_noised_sequence never deletes or masks EOS."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import torch
+
+from flexmdm.loss_flexmdm import get_noised_sequence
+from flexmdm.noise_flexmdm import FlexMDMNoiseSchedule, LinearSchedule
+
+
+def test_get_noised_sequence_preserves_eos_when_fixed_zero_at_eos():
+    pad, mask, eos = 0, 99, 10
+    # [content, content, eos, pad, pad] — EOS not in fixed (simulates mis-fixed collate)
+    x1 = torch.tensor([[1, 2, eos, pad, pad]])
+    fixed = torch.tensor([[0, 0, 0, 0, 0]])
+
+    schedule = FlexMDMNoiseSchedule(LinearSchedule(), LinearSchedule())
+    # Force all positions (including EOS) to be deletion-eligible without not_eos
+    schedule.insertion_noise_schedule.sample = MagicMock(
+        return_value=torch.full((1, 5), 0.99)
+    )
+    schedule.unmasking_noise_schedule.sample_truncated = MagicMock(
+        return_value=torch.full((1, 5), 0.5)
+    )
+
+    t = torch.tensor([0.5])
+    tokenizer = SimpleNamespace(
+        pad_token_id=pad, mask_token_id=mask, eos_token_id=eos
+    )
+
+    _, xt, _, _, _ = get_noised_sequence(
+        x1, 1, 5, t, fixed, schedule, tokenizer
+    )
+
+    # EOS must survive (other tokens may be deleted and squeezed left)
+    assert (xt[0] == eos).any()

--- a/tests/models/flexmdm/test_tokenizer_guards.py
+++ b/tests/models/flexmdm/test_tokenizer_guards.py
@@ -1,0 +1,53 @@
+"""Tests for FlexMDM tokenizer guards and Qwen pad registration."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from flexmdm.loss_flexmdm import FlexMDMLoss
+from flexmdm.noise_flexmdm import FlexMDMNoiseSchedule, LinearSchedule
+from flexmdm.predictor_flexmdm import FlexMDMPredictor
+from flexmdm.tokenizer_guards import require_distinct_pad_and_eos
+from xlm.datamodule import load_auto_tokenizer
+
+
+@pytest.fixture()
+def qwen_tokenizer():
+    return load_auto_tokenizer(
+        "Qwen/Qwen2-0.5B",
+        special_tokens={"mask_token": "<|mask|>", "pad_token": "<|pad|>"},
+    )
+
+
+def test_load_auto_tokenizer_qwen_pad_distinct_from_eos(qwen_tokenizer):
+    assert qwen_tokenizer.pad_token == "<|pad|>"
+    assert qwen_tokenizer.pad_token_id != qwen_tokenizer.eos_token_id
+
+
+def test_require_distinct_pad_and_eos_raises_when_equal():
+    tok = SimpleNamespace(pad_token_id=5, eos_token_id=5)
+    with pytest.raises(ValueError, match="pad_token_id != eos_token_id"):
+        require_distinct_pad_and_eos(tok)
+
+
+def test_require_distinct_pad_and_eos_passes_when_distinct():
+    tok = SimpleNamespace(pad_token_id=0, eos_token_id=10)
+    require_distinct_pad_and_eos(tok)
+
+
+def test_flexmdm_loss_raises_when_pad_equals_eos():
+    tok = SimpleNamespace(pad_token_id=1, eos_token_id=1, mask_token_id=2)
+    schedule = FlexMDMNoiseSchedule(LinearSchedule(), LinearSchedule())
+    with pytest.raises(ValueError, match="pad_token_id != eos_token_id"):
+        FlexMDMLoss(noise_schedule=schedule, tokenizer=tok)
+
+
+def test_flexmdm_predictor_raises_when_pad_equals_eos():
+    tok = SimpleNamespace(pad_token_id=1, eos_token_id=1, mask_token_id=2)
+    schedule = FlexMDMNoiseSchedule(LinearSchedule(), LinearSchedule())
+    with pytest.raises(ValueError, match="pad_token_id != eos_token_id"):
+        FlexMDMPredictor(
+            max_steps=4,
+            tokenizer=tok,
+            noise_schedule=schedule,
+        )

--- a/tests/tasks/test_tinygsm_debug_filter.py
+++ b/tests/tasks/test_tinygsm_debug_filter.py
@@ -1,0 +1,32 @@
+"""Tests for TinyGSM debug one-example filter."""
+
+import datasets
+
+from xlm.tasks.tinygsm import (
+    reset_tinygsm_debug_first_example_filter_fn,
+    tinygsm_debug_first_example_filter_fn,
+)
+
+
+def test_tinygsm_debug_first_example_filter_fn_keeps_one_row() -> None:
+    reset_tinygsm_debug_first_example_filter_fn()
+    ds = datasets.Dataset.from_dict(
+        {
+            "question": ["q0", "q1", "q2"],
+            "code": ["c0", "c1", "c2"],
+        }
+    )
+    filtered = ds.filter(tinygsm_debug_first_example_filter_fn)
+    assert len(filtered) == 1
+    assert filtered[0]["question"] == "q0"
+    assert filtered[0]["code"] == "c0"
+
+
+def test_tinygsm_debug_first_example_filter_fn_reset() -> None:
+    reset_tinygsm_debug_first_example_filter_fn()
+    ds = datasets.Dataset.from_dict({"question": ["a"], "code": ["b"]})
+    assert len(ds.filter(tinygsm_debug_first_example_filter_fn)) == 1
+    reset_tinygsm_debug_first_example_filter_fn()
+    ds2 = datasets.Dataset.from_dict({"question": ["x"], "code": ["y"]})
+    assert len(ds2.filter(tinygsm_debug_first_example_filter_fn)) == 1
+    assert ds2[0]["question"] == "x"

--- a/tests/tasks/test_tinygsm_gsm8k.py
+++ b/tests/tasks/test_tinygsm_gsm8k.py
@@ -1,0 +1,149 @@
+"""Tests for TinyGSM GSM8K preprocessing and code-execution eval."""
+
+from typing import Any, Dict, List
+
+import pytest
+
+from xlm.tasks.tinygsm.gsm8k import (
+    Gsm8kCodeEval,
+    evaluate_samples,
+    extract_gsm8k_final_answer,
+    gold_answer_from_tinygsm_code,
+    gsm8k_preprocess_fn,
+    prediction_code_text,
+    tinygsm_pred_preprocess_fn,
+)
+
+
+class _MockTokenizer:
+    def encode(self, text: str, add_special_tokens: bool = False) -> List[int]:
+        del add_special_tokens
+        return [ord(c) for c in text]
+
+
+def test_extract_gsm8k_final_answer_hash_marker() -> None:
+    assert extract_gsm8k_final_answer("Reasoning...\n#### 72") == "72"
+
+
+def test_extract_gsm8k_final_answer_commas_and_negative() -> None:
+    assert extract_gsm8k_final_answer("#### -1,234") == "-1234"
+
+
+def test_extract_gsm8k_final_answer_fallback_last_number() -> None:
+    assert extract_gsm8k_final_answer("The answer is 99 and also 100") == "100"
+
+
+def test_extract_gsm8k_final_answer_empty() -> None:
+    assert extract_gsm8k_final_answer("no numbers here") == ""
+
+
+def test_gsm8k_preprocess_fn() -> None:
+    tok = _MockTokenizer()
+    row: Dict[str, Any] = {
+        "question": "How many apples?",
+        "answer": "Step by step.\n#### 42",
+    }
+    out = gsm8k_preprocess_fn(row, tok, sep="\n")
+    assert out["answer"] == "42"
+    assert out["input_token_ids"] == []
+    assert out["prompt_token_ids"] == tok.encode("How many apples?") + tok.encode("\n")
+
+
+def test_gold_answer_from_tinygsm_code() -> None:
+    code = "def simple_math_problem():\n    return 42\n"
+    assert gold_answer_from_tinygsm_code(code) == "42"
+
+
+def test_tinygsm_pred_preprocess_fn() -> None:
+    tok = _MockTokenizer()
+    row: Dict[str, Any] = {
+        "question": "Q?",
+        "code": "def simple_math_problem():\n    return 7\n",
+    }
+    out = tinygsm_pred_preprocess_fn(row, tok, sep="\n")
+    assert out["answer"] == "7"
+    assert out["input_token_ids"] == []
+    assert out["prompt_token_ids"] == tok.encode("Q?") + tok.encode("\n")
+
+
+def test_evaluate_samples_valid_code() -> None:
+    code = "def simple_math_problem():\n    return 42\n"
+    assert evaluate_samples(code, "42")
+
+
+def test_evaluate_samples_wrong_answer() -> None:
+    code = "def simple_math_problem():\n    return 41\n"
+    assert not evaluate_samples(code, "42")
+
+
+def test_evaluate_samples_missing_function() -> None:
+    assert not evaluate_samples("x = 1", "1")
+
+
+def test_gsm8k_code_eval_aggregates() -> None:
+    evaluator = Gsm8kCodeEval(timeout_s=1.0)
+    preds = [
+        {
+            "text": "def simple_math_problem():\n    return 10\n",
+            "answer": "10",
+        },
+        {
+            "text": "def simple_math_problem():\n    return 9\n",
+            "answer": "10",
+        },
+    ]
+    updated, metrics = evaluator.eval(preds)
+    assert len(updated) == 2
+    assert updated[0]["correct"] is True
+    assert updated[1]["correct"] is False
+    assert metrics["code_exec_accuracy"] == 0.5
+    assert metrics["n_correct"] == 1
+    assert metrics["n_total"] == 2
+
+
+def test_gsm8k_code_eval_truth_field() -> None:
+    evaluator = Gsm8kCodeEval()
+    preds = [
+        {
+            "text": "def simple_math_problem():\n    return 7\n",
+            "truth": "7",
+        },
+    ]
+    _, metrics = evaluator.eval(preds)
+    assert metrics["code_exec_accuracy"] == 1.0
+
+
+def test_prediction_code_text_prefers_generated_text() -> None:
+    assert (
+        prediction_code_text(
+            {
+                "text": "question\n",
+                "generated_text": "def simple_math_problem():\n    return 1\n",
+            }
+        )
+        == "def simple_math_problem():\n    return 1\n"
+    )
+
+
+def test_prediction_code_text_falls_back_to_text() -> None:
+    assert prediction_code_text({"text": "only full"}) == "only full"
+
+
+def test_gsm8k_code_eval_uses_generated_text() -> None:
+    evaluator = Gsm8kCodeEval()
+    preds = [
+        {
+            "text": "ignore this prefix",
+            "generated_text": "def simple_math_problem():\n    return 3\n",
+            "answer": "3",
+        },
+    ]
+    _, metrics = evaluator.eval(preds)
+    assert metrics["code_exec_accuracy"] == 1.0
+
+
+def test_gsm8k_code_eval_empty_predictions() -> None:
+    evaluator = Gsm8kCodeEval()
+    preds, metrics = evaluator.eval([])
+    assert preds == []
+    assert metrics == {}

--- a/xlm-models/arlm/configs/datamodule/tinygsm_arlm.yaml
+++ b/xlm-models/arlm/configs/datamodule/tinygsm_arlm.yaml
@@ -4,6 +4,8 @@ defaults:
   - /datasets@datamodule.dataset_managers.train.lm: tinygsm_train
   - /datasets@datamodule.dataset_managers.val.lm: tinygsm_val
   - /datasets@datamodule.dataset_managers.val.prediction: tinygsm_val_pred
+  - /datasets@datamodule.dataset_managers.test.gsm8k_prediction: gsm8k_test_pred
+  - /collator@datamodule.dataset_managers.test.gsm8k_prediction.collator: seq2seq_pred_arlm
 
 datamodule:
   print_batch_fn: arlm.datamodule_arlm.print_batch_arlm
@@ -17,6 +19,10 @@ datamodule:
         collator:
           add_bos: null
       prediction:
+        collator:
+          add_bos: null
+    test:
+      gsm8k_prediction:
         collator:
           add_bos: null
 

--- a/xlm-models/arlm/configs/datamodule/tinygsm_arlm.yaml
+++ b/xlm-models/arlm/configs/datamodule/tinygsm_arlm.yaml
@@ -1,0 +1,24 @@
+# @package _global_
+defaults:
+  - star_arlm
+  - /datasets@datamodule.dataset_managers.train.lm: tinygsm_train
+  - /datasets@datamodule.dataset_managers.val.lm: tinygsm_val
+  - /datasets@datamodule.dataset_managers.val.prediction: tinygsm_val_pred
+
+datamodule:
+  print_batch_fn: arlm.datamodule_arlm.print_batch_arlm
+  dataset_managers:
+    train:
+      lm:
+        collator:
+          add_bos: null
+    val:
+      lm:
+        collator:
+          add_bos: null
+      prediction:
+        collator:
+          add_bos: null
+
+tags:
+  dataset: tinygsm

--- a/xlm-models/arlm/configs/experiment/tinygsm_arlm.yaml
+++ b/xlm-models/arlm/configs/experiment/tinygsm_arlm.yaml
@@ -2,7 +2,7 @@
 defaults:
   - override /datamodule: tinygsm_arlm
   - override /noise_schedule: dummy
-  - override /model_type: arlm_seq2seq
+  - override /model_type: arlm_tinygsm_seq2seq
   - override /model: rotary_transformer_small_arlm
 
 per_device_batch_size: 32
@@ -50,8 +50,16 @@ log_predictions:
   _target_: xlm.log_predictions.LogPredictions
   fields_to_keep_in_output:
     - text
-    - truth
-  inject_target: target_ids
+    - generated_text
+    - answer
+  additional_fields_from_batch:
+    - answer
   writers:
     - file
     - logger
+
+post_hoc_evaluator:
+  _target_: xlm.tasks.composite_eval.CompositePostHocEvaluator
+  evaluators:
+    prediction:
+      _target_: xlm.tasks.tinygsm.Gsm8kCodeEval

--- a/xlm-models/arlm/configs/experiment/tinygsm_arlm.yaml
+++ b/xlm-models/arlm/configs/experiment/tinygsm_arlm.yaml
@@ -1,0 +1,57 @@
+# @package _global_
+defaults:
+  - override /datamodule: tinygsm_arlm
+  - override /noise_schedule: dummy
+  - override /model_type: arlm_seq2seq
+  - override /model: rotary_transformer_small_arlm
+
+per_device_batch_size: 32
+global_batch_size: 512
+num_dataloader_workers: 5
+block_size: 512
+input_block_size: 0
+monitored_metric: val/lm/accumulated_loss
+
+global_components:
+  tokenizer:
+    _target_: xlm.datamodule.load_auto_tokenizer
+    pretrained_model_name_or_path: Qwen/Qwen2-0.5B
+    special_tokens:
+      mask_token: "<|mask|>"
+
+datamodule:
+  print_batch_fn: arlm.datamodule_arlm.print_batch_arlm
+
+trainer:
+  max_steps: 1000_000
+  val_check_interval: 50000
+  check_val_every_n_epoch: null
+  num_sanity_val_steps: 3
+
+optimizer:
+  lr: 0.0001
+
+lr_scheduler:
+  name: constant_with_warmup
+  num_warmup_steps: 2000
+  num_training_steps: ${trainer.max_steps}
+  monitor: train/loss
+
+callbacks:
+  checkpoint_every_n_steps:
+    every_n_train_steps: 2500
+    keep_multiple: 40
+
+predictor:
+  sampling_method: sample_top_k
+  top: 1
+
+log_predictions:
+  _target_: xlm.log_predictions.LogPredictions
+  fields_to_keep_in_output:
+    - text
+    - truth
+  inject_target: target_ids
+  writers:
+    - file
+    - logger

--- a/xlm-models/arlm/configs/model_type/arlm_tinygsm_seq2seq.yaml
+++ b/xlm-models/arlm/configs/model_type/arlm_tinygsm_seq2seq.yaml
@@ -1,0 +1,41 @@
+# @package _global_
+defaults:
+  - /metrics@reported_metrics.train.lm.accumulated_loss: accumulated_loss
+  - /metrics@reported_metrics.val.lm.accumulated_loss: accumulated_loss
+  - /metrics@reported_metrics.test.lm.accumulated_loss: accumulated_loss
+
+lightning_module:
+  _target_: xlm.harness.Harness
+
+loss:
+  _target_: arlm.loss_arlm.ARLMLoss
+
+predictor:
+  _target_: arlm.predictor_arlm.ARLMPredictor
+  tokenizer: ${lightning_module:tokenizer}
+  noise_schedule: ${lightning_module:noise_schedule}
+  max_steps: ${block_size}
+  max_length: ${eval:${block_size}+${oc.select:input_block_size,0}}
+  sampling_method: sample_top_p
+  p: 0.5
+
+diagnostic_metrics: null
+reported_metrics:
+  train:
+    lm:
+      accumulated_loss:
+        prefix: train/lm
+        update_fn: arlm.metrics_arlm.mean_metric_update_fn
+  val:
+    lm:
+      accumulated_loss:
+        prefix: val/lm
+        update_fn: arlm.metrics_arlm.mean_metric_update_fn
+  test:
+    lm:
+      accumulated_loss:
+        prefix: test/lm
+        update_fn: arlm.metrics_arlm.mean_metric_update_fn
+
+tags:
+  model_type: arlm_tinygsm_seq2seq

--- a/xlm-models/flexmdm/configs/collator/seq2seq_pred_flexmdm.yaml
+++ b/xlm-models/flexmdm/configs/collator/seq2seq_pred_flexmdm.yaml
@@ -2,3 +2,5 @@ _target_: flexmdm.datamodule_flexmdm.FlexMDMPredCollator
 input_block_size: ${input_block_size} # we expect input_block_size to be set in the experiment config
 block_size: ${block_size}
 tokenizer: ${global_components:tokenizer}
+pass_through_fields:
+  - answer

--- a/xlm-models/flexmdm/configs/datamodule/gsm8k_flexmdm.yaml
+++ b/xlm-models/flexmdm/configs/datamodule/gsm8k_flexmdm.yaml
@@ -1,0 +1,16 @@
+# @package _global_
+defaults:
+  - default
+  - /collator@datamodule.dataset_managers.test.gsm8k_prediction.collator: seq2seq_pred_flexmdm
+  - /datasets@datamodule.dataset_managers.test.gsm8k_prediction: gsm8k_test_pred
+
+datamodule:
+  print_batch_fn: flexmdm.datamodule_flexmdm.print_batch_flexmdm
+  dataset_managers:
+    test:
+      gsm8k_prediction:
+        collator:
+          add_bos: false
+
+tags:
+  dataset: gsm8k

--- a/xlm-models/flexmdm/configs/datamodule/safe_flexmdm_fragment.yaml
+++ b/xlm-models/flexmdm/configs/datamodule/safe_flexmdm_fragment.yaml
@@ -15,14 +15,23 @@ datamodule:
       infill_prediction:
         collator:
           add_bos: false
+          pass_through_fields:
+            - fragment_smiles
+            - original_smiles
     predict:
       infill_prediction:
         collator:
           add_bos: false
+          pass_through_fields:
+            - fragment_smiles
+            - original_smiles
     test:
       infill_prediction:
         collator:
           add_bos: false
+          pass_through_fields:
+            - fragment_smiles
+            - original_smiles
 
 
 tags:

--- a/xlm-models/flexmdm/configs/datamodule/tinygsm_flexmdm.yaml
+++ b/xlm-models/flexmdm/configs/datamodule/tinygsm_flexmdm.yaml
@@ -4,6 +4,11 @@ defaults:
   - /datasets@datamodule.dataset_managers.train.lm: tinygsm_train
   - /datasets@datamodule.dataset_managers.val.lm: tinygsm_val
   - /datasets@datamodule.dataset_managers.val.prediction: tinygsm_val_pred
+  - /datasets@datamodule.dataset_managers.test.lm: tinygsm_test
+  - /datasets@datamodule.dataset_managers.test.prediction: tinygsm_test_pred
+  - /datasets@datamodule.dataset_managers.predict.prediction: tinygsm_test_pred
+  - /datasets@datamodule.dataset_managers.test.gsm8k_prediction: gsm8k_test_pred
+  - /collator@datamodule.dataset_managers.test.gsm8k_prediction.collator: seq2seq_pred_flexmdm
 
 datamodule:
   print_batch_fn: flexmdm.datamodule_flexmdm.print_batch_flexmdm
@@ -16,6 +21,20 @@ datamodule:
       lm:
         collator:
           add_bos: false
+      prediction:
+        collator:
+          add_bos: false
+    test:
+      lm:
+        collator:
+          add_bos: false
+      prediction:
+        collator:
+          add_bos: false
+      gsm8k_prediction:
+        collator:
+          add_bos: false
+    predict:
       prediction:
         collator:
           add_bos: false

--- a/xlm-models/flexmdm/configs/datamodule/tinygsm_flexmdm.yaml
+++ b/xlm-models/flexmdm/configs/datamodule/tinygsm_flexmdm.yaml
@@ -1,0 +1,24 @@
+# @package _global_
+defaults:
+  - star_flexmdm
+  - /datasets@datamodule.dataset_managers.train.lm: tinygsm_train
+  - /datasets@datamodule.dataset_managers.val.lm: tinygsm_val
+  - /datasets@datamodule.dataset_managers.val.prediction: tinygsm_val_pred
+
+datamodule:
+  print_batch_fn: flexmdm.datamodule_flexmdm.print_batch_flexmdm
+  dataset_managers:
+    train:
+      lm:
+        collator:
+          add_bos: false
+    val:
+      lm:
+        collator:
+          add_bos: false
+      prediction:
+        collator:
+          add_bos: false
+
+tags:
+  dataset: tinygsm

--- a/xlm-models/flexmdm/configs/datasets/tinygsm_debug_one.yaml
+++ b/xlm-models/flexmdm/configs/datasets/tinygsm_debug_one.yaml
@@ -1,0 +1,13 @@
+defaults:
+  - tinygsm
+
+filter_fn: xlm.tasks.tinygsm.tinygsm_debug_first_example_filter_fn
+filter_suffix: debug_one
+iterable_dataset_shards: null
+shuffle_buffer_size: null
+on_the_fly_load_from_cache_file: false
+stages:
+  - fit
+  - validate
+dataloader_kwargs:
+  drop_last: false

--- a/xlm-models/flexmdm/configs/datasets/tinygsm_debug_one_pred.yaml
+++ b/xlm-models/flexmdm/configs/datasets/tinygsm_debug_one_pred.yaml
@@ -1,18 +1,15 @@
 defaults:
-  - tinygsm_val
+  - tinygsm_debug_one
 
-filter_suffix: pred_preprocess
+filter_suffix: debug_one_pred
 preprocess_function: xlm.tasks.tinygsm.tinygsm_pred_preprocess_fn
 preprocess_function_kwargs:
   sep: "\n"
 columns_to_remove:
   - question
   - code
+on_the_fly_load_from_cache_file: false
 stages:
   - fit
   - validate
   - predict
-iterable_dataset_shards: null
-shuffle_buffer_size: null
-dataloader_kwargs:
-  drop_last: false

--- a/xlm-models/flexmdm/configs/debug/overfit_tinygsm_flexmdm.yaml
+++ b/xlm-models/flexmdm/configs/debug/overfit_tinygsm_flexmdm.yaml
@@ -1,0 +1,29 @@
+# @package _global_
+defaults:
+  - /debug/overfit
+  - override /datasets@datamodule.dataset_managers.train.lm: tinygsm_debug_one
+  - override /datasets@datamodule.dataset_managers.val.lm: tinygsm_debug_one
+  - override /datasets@datamodule.dataset_managers.val.prediction: tinygsm_debug_one_pred
+
+tags:
+  debug: overfit_tinygsm_flexmdm
+
+datamodule:
+  dataset_managers:
+    train:
+      lm:
+        collator:
+          add_bos: false
+    val:
+      lm:
+        collator:
+          add_bos: false
+      prediction:
+        collator:
+          add_bos: false
+
+predictor:
+  confidence: null
+  top_k: 1
+  top_p: null
+  max_steps: 1024

--- a/xlm-models/flexmdm/configs/experiment/safe_flexmdm.yaml
+++ b/xlm-models/flexmdm/configs/experiment/safe_flexmdm.yaml
@@ -6,6 +6,7 @@ defaults:
   - override /noise_schedule: flexmdm_linear
   - override /model_type: flexmdm
   - override /model: ddit_flexmdm
+  - override /post_hoc_evaluator: denovo
 
 per_device_batch_size: 128
 global_batch_size: 2048
@@ -15,11 +16,6 @@ num_dataloader_workers: 4
 use_bracket_safe: true
 num_unconditional_prediction_examples: 1000
 len_predict_type: expectation
-
-# post-hoc evaluation
-post_hoc_evaluator:
-  _target_: xlm.tasks.safe_molgen.DeNovoEval
-  use_bracket_safe: ${oc.select:use_bracket_safe,true}
 
 datamodule:
   print_batch_fn: flexmdm.datamodule_flexmdm.print_batch_flexmdm

--- a/xlm-models/flexmdm/configs/experiment/safe_flexmdm_fragment.yaml
+++ b/xlm-models/flexmdm/configs/experiment/safe_flexmdm_fragment.yaml
@@ -7,6 +7,7 @@ defaults:
   - override /noise_schedule: flexmdm_linear
   - override /model_type: flexmdm
   - override /model: ddit_flexmdm
+  - override /post_hoc_evaluator: fragment
 
 per_device_batch_size: 128
 global_batch_size: 2048
@@ -18,14 +19,6 @@ num_unconditional_prediction_examples: 1000
 num_conditional_prediction_samples: 10
 len_predict_type: expectation
 molgen_task_name: motif_extension
-
-# post-hoc evaluation
-post_hoc_evaluator:
-  _target_: xlm.tasks.safe_molgen.FragmentEval
-  task_name: ${molgen_task_name}
-  num_samples: ${num_conditional_prediction_samples}
-  use_bracket_safe: ${oc.select:use_bracket_safe,true}
-  compute_distance: true
 
 predictor:
   _target_: flexmdm.predictor_flexmdm.FlexMDMPredictor

--- a/xlm-models/flexmdm/configs/experiment/tinygsm_flexmdm.yaml
+++ b/xlm-models/flexmdm/configs/experiment/tinygsm_flexmdm.yaml
@@ -1,0 +1,65 @@
+# @package _global_
+defaults:
+  - text_flexmdm
+  - override /datamodule: tinygsm_flexmdm
+  - override /noise_schedule: flexmdm_linear
+  - override /model_type: flexmdm_seq2seq
+  - override /model: ddit_flexmdm
+
+per_device_batch_size: 32
+global_batch_size: 512
+num_dataloader_workers: 5
+block_size: 512
+input_block_size: 0
+len_predict_type: expectation
+monitored_metric: val/lm/accumulated_loss
+
+model:
+  force_flash_attn: false
+  len_head_type: mlp
+
+trainer:
+  max_steps: 1000_000
+  val_check_interval: 50000
+  check_val_every_n_epoch: null
+  num_sanity_val_steps: 3
+
+optimizer:
+  lr: 0.0001
+
+lr_scheduler:
+  name: constant_with_warmup
+  num_warmup_steps: 2000
+  num_training_steps: ${trainer.max_steps}
+  monitor: train/loss
+
+callbacks:
+  checkpoint_every_n_steps:
+    every_n_train_steps: 2500
+    keep_multiple: 40
+
+global_components:
+  tokenizer:
+    _target_: xlm.datamodule.load_auto_tokenizer
+    pretrained_model_name_or_path: Qwen/Qwen2-0.5B
+    special_tokens:
+      mask_token: "<|mask|>"
+
+datamodule:
+  print_batch_fn: flexmdm.datamodule_flexmdm.print_batch_flexmdm
+
+predictor:
+  confidence: null
+  top_k: null
+  top_p: null
+  max_steps: ${block_size}
+
+log_predictions:
+  _target_: xlm.log_predictions.LogPredictions
+  fields_to_keep_in_output:
+    - text
+    - truth
+  inject_target: target_ids
+  writers:
+    - file
+    - logger

--- a/xlm-models/flexmdm/configs/experiment/tinygsm_flexmdm.yaml
+++ b/xlm-models/flexmdm/configs/experiment/tinygsm_flexmdm.yaml
@@ -44,6 +44,7 @@ global_components:
     pretrained_model_name_or_path: Qwen/Qwen2-0.5B
     special_tokens:
       mask_token: "<|mask|>"
+      pad_token: "<|pad|>"
 
 datamodule:
   print_batch_fn: flexmdm.datamodule_flexmdm.print_batch_flexmdm

--- a/xlm-models/flexmdm/configs/experiment/tinygsm_flexmdm_gsm8k_eval.yaml
+++ b/xlm-models/flexmdm/configs/experiment/tinygsm_flexmdm_gsm8k_eval.yaml
@@ -25,6 +25,7 @@ global_components:
     pretrained_model_name_or_path: Qwen/Qwen2-0.5B
     special_tokens:
       mask_token: "<|mask|>"
+      pad_token: "<|pad|>"
 
 datamodule:
   print_batch_fn: flexmdm.datamodule_flexmdm.print_batch_flexmdm

--- a/xlm-models/flexmdm/configs/experiment/tinygsm_flexmdm_gsm8k_eval.yaml
+++ b/xlm-models/flexmdm/configs/experiment/tinygsm_flexmdm_gsm8k_eval.yaml
@@ -1,42 +1,23 @@
 # @package _global_
+# Standalone GSM8K test eval for a trained TinyGSM FlexMDM checkpoint.
 defaults:
   - text_flexmdm
-  - override /datamodule: tinygsm_flexmdm
+  - override /datamodule: gsm8k_flexmdm
   - override /noise_schedule: flexmdm_linear
-  - override /model_type: flexmdm_tinygsm_seq2seq
+  - override /model_type: flexmdm_seq2seq
   - override /model: ddit_flexmdm
 
 per_device_batch_size: 32
-global_batch_size: 512
+global_batch_size: 32
 num_dataloader_workers: 5
 block_size: 512
 input_block_size: 0
 len_predict_type: expectation
-monitored_metric: val/lm/accumulated_loss
+monitored_metric: null
 
 model:
   force_flash_attn: false
   len_head_type: mlp
-
-trainer:
-  max_steps: 1000_000
-  val_check_interval: 50000
-  check_val_every_n_epoch: null
-  num_sanity_val_steps: 3
-
-optimizer:
-  lr: 0.0001
-
-lr_scheduler:
-  name: constant_with_warmup
-  num_warmup_steps: 2000
-  num_training_steps: ${trainer.max_steps}
-  monitor: train/loss
-
-callbacks:
-  checkpoint_every_n_steps:
-    every_n_train_steps: 2500
-    keep_multiple: 40
 
 global_components:
   tokenizer:
@@ -64,10 +45,17 @@ log_predictions:
     - answer
   writers:
     - file
-    - logger
 
 post_hoc_evaluator:
-  _target_: xlm.tasks.composite_eval.CompositePostHocEvaluator
-  evaluators:
-    prediction:
-      _target_: xlm.tasks.tinygsm.Gsm8kCodeEval
+  _target_: xlm.tasks.tinygsm.Gsm8kCodeEval
+
+eval:
+  split: test
+
+trainer:
+  max_steps: 0
+  num_sanity_val_steps: 0
+  limit_test_batches: null
+
+tags:
+  dataset: gsm8k

--- a/xlm-models/flexmdm/configs/model_type/flexmdm_tinygsm_seq2seq.yaml
+++ b/xlm-models/flexmdm/configs/model_type/flexmdm_tinygsm_seq2seq.yaml
@@ -1,0 +1,47 @@
+# @package _global_
+# Seq2seq FlexMDM without token-level prediction metrics (use post-hoc code exec).
+defaults:
+  - /metrics@reported_metrics.train.lm.accumulated_loss: accumulated_loss
+  - /metrics@reported_metrics.val.lm.accumulated_loss: accumulated_loss
+  - /metrics@reported_metrics.test.lm.accumulated_loss: accumulated_loss
+
+lightning_module:
+  _target_: xlm.harness.Harness
+
+loss:
+  _target_: flexmdm.loss_flexmdm.FlexMDMLoss
+  loss_on_padding: true
+  loss_on_visible_tokens: false
+  insert_loss_fn: ${len_predict_type}
+  noise_schedule: ${global_components:noise_schedule}
+
+predictor:
+  _target_: flexmdm.predictor_flexmdm.FlexMDMPredictor
+  tokenizer: ${global_components:tokenizer}
+  noise_schedule: ${global_components:noise_schedule}
+  max_steps: ${block_size}
+  max_new_tokens: null
+  top_k: 1
+  top_p: null
+  len_predict_type: ${len_predict_type}
+
+diagnostic_metrics: null
+reported_metrics:
+  train:
+    lm:
+      accumulated_loss:
+        prefix: train/lm
+        update_fn: flexmdm.metrics_flexmdm.mean_metric_update_fn
+  val:
+    lm:
+      accumulated_loss:
+        prefix: val/lm
+        update_fn: flexmdm.metrics_flexmdm.mean_metric_update_fn
+  test:
+    lm:
+      accumulated_loss:
+        prefix: test/lm
+        update_fn: flexmdm.metrics_flexmdm.mean_metric_update_fn
+
+tags:
+  model_type: flexmdm_tinygsm_seq2seq

--- a/xlm-models/flexmdm/datamodule_flexmdm.py
+++ b/xlm-models/flexmdm/datamodule_flexmdm.py
@@ -9,7 +9,7 @@ from jaxtyping import Float, Integer
 from torch.utils.data import IterableDataset
 from torch import Tensor as TT
 from .types_flexmdm import FlexMDMBatch
-from typing import Callable, Dict, List, Literal, Optional, Any, Union
+from typing import Callable, Dict, List, Literal, Mapping, Optional, Any, Union
 from .types_flexmdm import FlexMDMBatch
 from .noise_flexmdm import FlexMDMNoiseSchedule
 from xlm.utils.nn import pad_truncate_list
@@ -697,6 +697,19 @@ class FlexMDMTrainCollator(Collator):
         )
 
 
+def _merge_pass_through_fields(
+    examples: List[Mapping[str, Any]],
+    batch: Dict[str, Any],
+    pass_through_fields: Optional[List[str]],
+) -> Dict[str, Any]:
+    if not examples or not pass_through_fields:
+        return batch
+    for key in pass_through_fields:
+        if key in examples[0]:
+            batch[key] = [ex[key] for ex in examples]
+    return batch
+
+
 def flexmdm_pred_collate_fn(
     num_examples: int,
     prompt_ids: Optional[List[List[int]]],
@@ -705,6 +718,8 @@ def flexmdm_pred_collate_fn(
     bos_token_id: Optional[int],
     eos_token_id: int,
     max_seq_len: Optional[int] = None,
+    pass_through_fields: Optional[List[str]] = None,
+    examples: Optional[List[Mapping[str, Any]]] = None,
 ) -> Dict[str, Optional[TT]]:
 
     if prompt_ids is not None:  # conditional case: start with [prefix] [bos]
@@ -752,7 +767,9 @@ def flexmdm_pred_collate_fn(
         target_ids = torch.tensor(target_ids)
     # --
 
-    ret = {"input_ids": ids, "fixed": fixed_gaps, "target_ids": target_ids}
+    ret: Dict[str, Any] = {"input_ids": ids, "fixed": fixed_gaps, "target_ids": target_ids}
+    if examples is not None:
+        _merge_pass_through_fields(examples, ret, pass_through_fields)
     return ret
 
 
@@ -780,11 +797,17 @@ class FlexMDMPredCollator(Collator):
         block_size: int,
         input_block_size: Optional[int] = 0,
         add_bos: bool = True,
+        pass_through_fields: Optional[List[str]] = None,
     ):
         self.block_size = block_size
         self.input_block_size = input_block_size
         self.tokenizer = tokenizer
         self.add_bos = add_bos
+        self.pass_through_fields = (
+            list(pass_through_fields)
+            if pass_through_fields is not None
+            else ["answer"]
+        )
         try:
             self._vocab_size = len(self.tokenizer)
         except TypeError:
@@ -809,6 +832,8 @@ class FlexMDMPredCollator(Collator):
                 if has_prefix
                 else self.block_size
             ),
+            pass_through_fields=self.pass_through_fields,
+            examples=examples,
         )
 
 

--- a/xlm-models/flexmdm/datamodule_flexmdm.py
+++ b/xlm-models/flexmdm/datamodule_flexmdm.py
@@ -767,7 +767,11 @@ def flexmdm_pred_collate_fn(
         target_ids = torch.tensor(target_ids)
     # --
 
-    ret: Dict[str, Any] = {"input_ids": ids, "fixed": fixed_gaps, "target_ids": target_ids}
+    ret: Dict[str, Any] = {
+        "input_ids": ids,
+        "fixed": fixed_gaps,
+        "target_ids": target_ids,
+    }
     if examples is not None:
         _merge_pass_through_fields(examples, ret, pass_through_fields)
     return ret

--- a/xlm-models/flexmdm/loss_flexmdm.py
+++ b/xlm-models/flexmdm/loss_flexmdm.py
@@ -3,6 +3,7 @@ from typing import Optional, cast
 import torch
 import torch.nn.functional as F
 from .noise_flexmdm import FlexMDMNoiseSchedule
+from .tokenizer_guards import require_distinct_pad_and_eos
 from .types_flexmdm import FlexMDMBatch, FlexMDMLossDict, FlexMDMModel
 from xlm.harness import LossFunction, Harness
 from xlm.datamodule import Tokenizer
@@ -48,11 +49,13 @@ def get_noised_sequence(
     eos_token_id = tokenizer.eos_token_id
     
     clean_tokens = x1.ne(pad_token_id)
-    deleted_tokens = clean_tokens & (t[:, None] < insertion_time)
+    not_eos = x1.ne(eos_token_id)
+    deleted_tokens = clean_tokens & (t[:, None] < insertion_time) & not_eos
     masked_tokens = (
         clean_tokens
         & (t[:, None] >= insertion_time)
         & (t[:, None] < unmasking_time)
+        & not_eos
     )
 
     xt = torch.where(
@@ -117,6 +120,8 @@ class FlexMDMLoss(LossFunction[FlexMDMBatch, FlexMDMLossDict]):
         self.tokenizer = tokenizer
         self.insert_loss_fn = insert_loss_fn
         self.mask_token_id_tensor = None
+        if tokenizer is not None:
+            require_distinct_pad_and_eos(tokenizer)
 
     def configure(self, pl_module: Harness):
         self.mask_token_id_tensor = torch.tensor(  # type: ignore

--- a/xlm-models/flexmdm/predictor_flexmdm.py
+++ b/xlm-models/flexmdm/predictor_flexmdm.py
@@ -13,6 +13,7 @@ import torch
 from jaxtyping import Bool, Integer, Float
 from xlm.datamodule import Tokenizer
 from torch import Tensor as TT
+from .tokenizer_guards import require_distinct_pad_and_eos
 from .types_flexmdm import (
     FlexMDMBatch,
     FlexMDMPredictionDict,
@@ -147,6 +148,7 @@ class FlexMDMPredictor(
         self.confidence = confidence
         self.tokens_hook = None
         self.skip_special_tokens_in_history = skip_special_tokens_in_history
+        require_distinct_pad_and_eos(self.tokenizer)
 
     def reset(self):
         # simple predictor has no state

--- a/xlm-models/flexmdm/predictor_flexmdm.py
+++ b/xlm-models/flexmdm/predictor_flexmdm.py
@@ -34,6 +34,33 @@ import time
 FlexMDMStepResults = Dict[str, Any]
 
 
+def decode_generation_suffix(
+    token_ids: Integer[TT, " batch seq_len"],
+    fixed: Integer[TT, " batch seq_len"],
+    tokenizer: Tokenizer,
+    *,
+    skip_special_tokens: bool = True,
+) -> List[str]:
+    """Decode only the generated (non-fixed, non-pad) region for seq2seq prediction.
+
+    FlexMDM pred batches set ``fixed=1`` on the question prefix and ``fixed=0`` on
+    the suffix where the model generates code. Full-sequence ``batch_decode`` is
+    kept in ``text`` for debugging; this helper is for downstream code-exec eval.
+    """
+    pad = tokenizer.pad_token_id
+    decoded: List[str] = []
+    for row_ids, row_fixed in zip(
+        token_ids.detach().cpu().tolist(), fixed.detach().cpu().tolist()
+    ):
+        gen_ids = [
+            tid for tid, f in zip(row_ids, row_fixed) if f == 0 and tid != pad
+        ]
+        decoded.append(
+            tokenizer.decode(gen_ids, skip_special_tokens=skip_special_tokens)
+        )
+    return decoded
+
+
 class FlexMDMTokensHook(TokensHook):
     def __call__(
         self,
@@ -171,8 +198,21 @@ class FlexMDMPredictor(
         formatted_history = self.format_history_for_output(
             history_data, round_precision=4
         )
+        if "generated_text" in preds:
+            generated_text = preds["generated_text"]
+        elif "fixed" in batch:
+            generated_text = decode_generation_suffix(
+                preds["ids"],
+                batch["fixed"],
+                self.tokenizer,
+                skip_special_tokens=self.skip_special_tokens_in_history,
+            )
+        else:
+            generated_text = preds["text"]
+
         to_zip = [
             preds["text"],
+            generated_text,
             preds["ids"].tolist(),
             formatted_history,
             preds.get("time_taken", cycle([-1])),
@@ -183,18 +223,17 @@ class FlexMDMPredictor(
                 metric_keys.append(n)
                 to_zip.append(preds[n])
 
-        preds_list: List[Tuple[str, List[int], List[List[Any]], float]] = list(
-            zip(*to_zip)
-        )
+        preds_list = list(zip(*to_zip))
         dicts: List[Dict[str, Any]] = []
         for preds_ in preds_list:
             dicts.append(
                 {
                     "text": preds_[0],
-                    "ids": preds_[1],
-                    "history": preds_[2],
-                    "time_taken": preds_[3],
-                    **{k: preds_[4 + i] for i, k in enumerate(metric_keys)},
+                    "generated_text": preds_[1],
+                    "ids": preds_[2],
+                    "history": preds_[3],
+                    "time_taken": preds_[4],
+                    **{k: preds_[5 + i] for i, k in enumerate(metric_keys)},
                 }
             )
         return dicts
@@ -506,14 +545,19 @@ class FlexMDMPredictor(
         out = self.tokenizer.batch_decode(
             xt, skip_special_tokens=self.skip_special_tokens_in_history
         )
-        # print("out")
-        # print(out)
+        generated_text = decode_generation_suffix(
+            xt,
+            fixed_gaps,
+            self.tokenizer,
+            skip_special_tokens=self.skip_special_tokens_in_history,
+        )
 
         _end_time = time.time()
         _time_taken = _end_time - _start_time
         self.reset()
         return {
             "text": out,
+            "generated_text": generated_text,
             "ids": xt,
             "loss": None,
             "time_taken": [_time_taken]

--- a/xlm-models/flexmdm/tokenizer_guards.py
+++ b/xlm-models/flexmdm/tokenizer_guards.py
@@ -1,0 +1,16 @@
+"""Tokenizer preconditions for FlexMDM training and prediction."""
+
+from xlm.datamodule import Tokenizer
+
+
+def require_distinct_pad_and_eos(tokenizer: Tokenizer) -> None:
+    """Raise if pad and eos share an id (breaks FlexMDM length / insertion logic)."""
+    pad_id = tokenizer.pad_token_id
+    eos_id = tokenizer.eos_token_id
+    if pad_id is None or eos_id is None:
+        raise ValueError("FlexMDM requires pad_token_id and eos_token_id to be set.")
+    if pad_id == eos_id:
+        raise ValueError(
+            f"FlexMDM requires pad_token_id != eos_token_id (both are {pad_id}). "
+            "Add pad_token: '<|pad|>' under global_components.tokenizer.special_tokens."
+        )

--- a/xlm-models/flexmdm/types_flexmdm.py
+++ b/xlm-models/flexmdm/types_flexmdm.py
@@ -76,7 +76,8 @@ class FlexMDMPredictionDict(TypedDict, total=False):
 
     Attributes:
         loss (Optional[Float[TT, "batch"]]): The loss value. Typically None.
-        text (List[str]): The batch of generated text with special tokens.
+        text (List[str]): Full decoded sequence (prefix + generated suffix).
+        generated_text (List[str]): Decoded suffix only (non-fixed region).
         ids (Integer[TT, " batch seq_len"]): The batch of generated token_ids.
         time_taken (List[float]): Time taken for each prediction.
         history (List[List[Tuple[str, float, int]]]): Generation history for each batch element.
@@ -86,6 +87,7 @@ class FlexMDMPredictionDict(TypedDict, total=False):
 
     loss: Optional[Float[TT, ""]]
     text: List[str]
+    generated_text: List[str]
     ids: Integer[TT, " batch seq_len"]
     time_taken: List[float]
     history: List[List[Tuple[str, float, int]]]

--- a/xlm-models/mlm/configs/datamodule/star_hard_mlm.yaml
+++ b/xlm-models/mlm/configs/datamodule/star_hard_mlm.yaml
@@ -1,0 +1,12 @@
+# @package _global_
+defaults:
+  - star_mlm
+  - /datasets@datamodule.dataset_managers.train.lm: star_hard_train
+  - /datasets@datamodule.dataset_managers.val.lm: star_hard_val
+  - /datasets@datamodule.dataset_managers.val.prediction: star_hard_val_pred
+  - /datasets@datamodule.dataset_managers.test.lm: star_hard_test
+  - /datasets@datamodule.dataset_managers.test.prediction: star_hard_test_pred
+  - /datasets@datamodule.dataset_managers.predict.prediction: star_hard_test_pred
+
+tags:
+  dataset: star_hard

--- a/xlm-models/mlm/configs/datamodule/star_medium_mlm.yaml
+++ b/xlm-models/mlm/configs/datamodule/star_medium_mlm.yaml
@@ -1,0 +1,12 @@
+# @package _global_
+defaults:
+  - star_mlm
+  - /datasets@datamodule.dataset_managers.train.lm: star_medium_train
+  - /datasets@datamodule.dataset_managers.val.lm: star_medium_val
+  - /datasets@datamodule.dataset_managers.val.prediction: star_medium_val_pred
+  - /datasets@datamodule.dataset_managers.test.lm: star_medium_test
+  - /datasets@datamodule.dataset_managers.test.prediction: star_medium_test_pred
+  - /datasets@datamodule.dataset_managers.predict.prediction: star_medium_test_pred
+
+tags:
+  dataset: star_medium

--- a/xlm-models/mlm/configs/datamodule/tinygsm_mlm.yaml
+++ b/xlm-models/mlm/configs/datamodule/tinygsm_mlm.yaml
@@ -4,6 +4,8 @@ defaults:
   - /datasets@datamodule.dataset_managers.train.lm: tinygsm_train
   - /datasets@datamodule.dataset_managers.val.lm: tinygsm_val
   - /datasets@datamodule.dataset_managers.val.prediction: tinygsm_val_pred
+  - /datasets@datamodule.dataset_managers.test.gsm8k_prediction: gsm8k_test_pred
+  - /collator@datamodule.dataset_managers.test.gsm8k_prediction.collator: seq2seq_pred_mlm
 
 datamodule:
   print_batch_fn: mlm.datamodule_mlm.print_batch_mlm
@@ -17,6 +19,10 @@ datamodule:
         collator:
           add_bos: false
       prediction:
+        collator:
+          add_bos: false
+    test:
+      gsm8k_prediction:
         collator:
           add_bos: false
 

--- a/xlm-models/mlm/configs/datamodule/tinygsm_mlm.yaml
+++ b/xlm-models/mlm/configs/datamodule/tinygsm_mlm.yaml
@@ -1,0 +1,24 @@
+# @package _global_
+defaults:
+  - star_mlm
+  - /datasets@datamodule.dataset_managers.train.lm: tinygsm_train
+  - /datasets@datamodule.dataset_managers.val.lm: tinygsm_val
+  - /datasets@datamodule.dataset_managers.val.prediction: tinygsm_val_pred
+
+datamodule:
+  print_batch_fn: mlm.datamodule_mlm.print_batch_mlm
+  dataset_managers:
+    train:
+      lm:
+        collator:
+          add_bos: false
+    val:
+      lm:
+        collator:
+          add_bos: false
+      prediction:
+        collator:
+          add_bos: false
+
+tags:
+  dataset: tinygsm

--- a/xlm-models/mlm/configs/experiment/star_easy_mlm.yaml
+++ b/xlm-models/mlm/configs/experiment/star_easy_mlm.yaml
@@ -23,9 +23,11 @@ predictor:
   top_k: 1
   top_p: null
   confidence: "top_prob"
+  threshold: 0.1
+  max_steps: 500
 
 trainer:
-  max_steps: 80000
+  max_steps: 300000
   val_check_interval: null
   num_sanity_val_steps: 3
   check_val_every_n_epoch: 2
@@ -48,7 +50,9 @@ optimizer:
   lr: 0.0001
 
 lr_scheduler:
-  name: "constant"
-  num_warmup_steps: 500
+  name: "cosine_with_min_lr"
+  min_lr: 1e-6
+  num_warmup_steps: 2000
+  num_cycles: 4
   num_training_steps: ${trainer.max_steps}
   monitor: "train/loss"

--- a/xlm-models/mlm/configs/experiment/star_easy_mlm.yaml
+++ b/xlm-models/mlm/configs/experiment/star_easy_mlm.yaml
@@ -19,6 +19,11 @@ global_components:
     _target_: xlm.datamodule.SimpleSpaceTokenizer.for_numbers
     vocab_size: 20 # 20 (easy,medium), 56 (hard)
 
+predictor:
+  top_k: 1
+  top_p: null
+  confidence: "top_prob"
+
 trainer:
   max_steps: 80000
   val_check_interval: null

--- a/xlm-models/mlm/configs/experiment/star_hard_mlm.yaml
+++ b/xlm-models/mlm/configs/experiment/star_hard_mlm.yaml
@@ -1,0 +1,21 @@
+# @package _global_
+defaults:
+  - star_easy_mlm
+  - override /datamodule: star_hard_mlm
+
+input_block_size: 116
+block_size: 28
+monitored_metric: val/lm/accumulated_loss
+
+datamodule:
+  print_batch_fn: mlm.datamodule_mlm.print_batch_mlm
+
+predictor:
+  top_k: 1
+  top_p: null
+  confidence: "top_prob"
+
+global_components:
+  tokenizer:
+    _target_: xlm.datamodule.SimpleSpaceTokenizer.for_numbers
+    vocab_size: 56 # 20 (easy,medium), 56 (hard)

--- a/xlm-models/mlm/configs/experiment/star_hard_mlm.yaml
+++ b/xlm-models/mlm/configs/experiment/star_hard_mlm.yaml
@@ -10,12 +10,25 @@ monitored_metric: val/lm/accumulated_loss
 datamodule:
   print_batch_fn: mlm.datamodule_mlm.print_batch_mlm
 
-predictor:
-  top_k: 1
-  top_p: null
-  confidence: "top_prob"
-
 global_components:
   tokenizer:
     _target_: xlm.datamodule.SimpleSpaceTokenizer.for_numbers
     vocab_size: 56 # 20 (easy,medium), 56 (hard)
+
+predictor:
+  top_k: 1
+  top_p: null
+  confidence: "top_prob"
+  threshold: 0.1
+  max_steps: 500
+
+trainer:
+  max_steps: 300000
+
+lr_scheduler:
+  name: "cosine_with_min_lr"
+  min_lr: 1e-6
+  num_warmup_steps: 2000
+  num_cycles: 4
+  num_training_steps: ${trainer.max_steps}
+  monitor: "train/loss"

--- a/xlm-models/mlm/configs/experiment/star_medium_mlm.yaml
+++ b/xlm-models/mlm/configs/experiment/star_medium_mlm.yaml
@@ -1,0 +1,21 @@
+# @package _global_
+defaults:
+  - star_easy_mlm
+  - override /datamodule: star_medium_mlm
+
+input_block_size: 36
+block_size: 16
+monitored_metric: val/lm/accumulated_loss
+
+datamodule:
+  print_batch_fn: mlm.datamodule_mlm.print_batch_mlm
+
+global_components:
+  tokenizer:
+    _target_: xlm.datamodule.SimpleSpaceTokenizer.for_numbers
+    vocab_size: 20 # 20 (easy,medium), 56 (hard)
+
+predictor:
+  top_k: 1
+  top_p: null
+  confidence: "top_prob"

--- a/xlm-models/mlm/configs/experiment/star_medium_mlm.yaml
+++ b/xlm-models/mlm/configs/experiment/star_medium_mlm.yaml
@@ -19,3 +19,16 @@ predictor:
   top_k: 1
   top_p: null
   confidence: "top_prob"
+  threshold: 0.1
+  max_steps: 500
+
+trainer:
+  max_steps: 300000
+
+lr_scheduler:
+  name: "cosine_with_min_lr"
+  min_lr: 1e-6
+  num_warmup_steps: 2000
+  num_cycles: 4
+  num_training_steps: ${trainer.max_steps}
+  monitor: "train/loss"

--- a/xlm-models/mlm/configs/experiment/tinygsm_mlm.yaml
+++ b/xlm-models/mlm/configs/experiment/tinygsm_mlm.yaml
@@ -2,7 +2,7 @@
 defaults:
   - override /datamodule: tinygsm_mlm
   - override /noise_schedule: dummy
-  - override /model_type: mlm_seq2seq
+  - override /model_type: mlm_tinygsm_seq2seq
   - override /model: rotary_transformer_mlm
 
 add_bos: false
@@ -48,8 +48,16 @@ log_predictions:
   _target_: xlm.log_predictions.LogPredictions
   fields_to_keep_in_output:
     - text
-    - truth
-  inject_target: target_ids
+    - generated_text
+    - answer
+  additional_fields_from_batch:
+    - answer
   writers:
     - file
     - logger
+
+post_hoc_evaluator:
+  _target_: xlm.tasks.composite_eval.CompositePostHocEvaluator
+  evaluators:
+    prediction:
+      _target_: xlm.tasks.tinygsm.Gsm8kCodeEval

--- a/xlm-models/mlm/configs/experiment/tinygsm_mlm.yaml
+++ b/xlm-models/mlm/configs/experiment/tinygsm_mlm.yaml
@@ -1,0 +1,55 @@
+# @package _global_
+defaults:
+  - override /datamodule: tinygsm_mlm
+  - override /noise_schedule: dummy
+  - override /model_type: mlm_seq2seq
+  - override /model: rotary_transformer_mlm
+
+add_bos: false
+add_eos: true
+per_device_batch_size: 32
+global_batch_size: 512
+num_dataloader_workers: 5
+block_size: 512
+input_block_size: 0
+monitored_metric: val/lm/accumulated_loss
+
+global_components:
+  tokenizer:
+    _target_: xlm.datamodule.load_auto_tokenizer
+    pretrained_model_name_or_path: Qwen/Qwen2-0.5B
+    special_tokens:
+      mask_token: "<|mask|>"
+
+datamodule:
+  print_batch_fn: mlm.datamodule_mlm.print_batch_mlm
+
+trainer:
+  max_steps: 1000_000
+  val_check_interval: 50000
+  check_val_every_n_epoch: null
+  num_sanity_val_steps: 3
+
+optimizer:
+  lr: 0.0001
+
+lr_scheduler:
+  name: constant_with_warmup
+  num_warmup_steps: 2000
+  num_training_steps: ${trainer.max_steps}
+  monitor: train/loss
+
+callbacks:
+  checkpoint_every_n_steps:
+    every_n_train_steps: 2500
+    keep_multiple: 40
+
+log_predictions:
+  _target_: xlm.log_predictions.LogPredictions
+  fields_to_keep_in_output:
+    - text
+    - truth
+  inject_target: target_ids
+  writers:
+    - file
+    - logger

--- a/xlm-models/mlm/configs/model_type/mlm_tinygsm_seq2seq.yaml
+++ b/xlm-models/mlm/configs/model_type/mlm_tinygsm_seq2seq.yaml
@@ -1,0 +1,41 @@
+# @package _global_
+defaults:
+  - /metrics@reported_metrics.train.lm.accumulated_loss: accumulated_loss
+  - /metrics@reported_metrics.val.lm.accumulated_loss: accumulated_loss
+  - /metrics@reported_metrics.test.lm.accumulated_loss: accumulated_loss
+
+lightning_module:
+  _target_: xlm.harness.Harness
+
+loss:
+  _target_: mlm.loss_mlm.MLMLoss
+
+predictor:
+  _target_: mlm.predictor_mlm.MLMPredictor
+  tokenizer: ${lightning_module:tokenizer}
+  noise_schedule: ${lightning_module:noise_schedule}
+  max_steps: ${block_size}
+  max_new_tokens: ${block_size}
+  top_k: 2
+  top_p: null
+
+diagnostic_metrics: null
+reported_metrics:
+  train:
+    lm:
+      accumulated_loss:
+        prefix: train/lm
+        update_fn: mlm.metrics_mlm.mean_metric_update_fn
+  val:
+    lm:
+      accumulated_loss:
+        prefix: val/lm
+        update_fn: mlm.metrics_mlm.mean_metric_update_fn
+  test:
+    lm:
+      accumulated_loss:
+        prefix: test/lm
+        update_fn: mlm.metrics_mlm.mean_metric_update_fn
+
+tags:
+  model_type: mlm_tinygsm_seq2seq


### PR DESCRIPTION
## Summary

- Adds `xlm.tasks.tinygsm.tinygsm_preprocess_fn` to split TinyGSM rows into `prompt_token_ids` (question + separator) and `input_token_ids` (code), following [PUMA tiny_gsm.py](https://github.com/JaeyeonKim01/PUMA/blob/main/data/tiny_gsm.py) field layout.
- Adds dataset configs `tinygsm_train` / `tinygsm_val` with a 5% held-out split (`seed: 2025`, matching PUMA) via `DatasetManager.train_test_split`.
- Adds `datamodule/tinygsm.yaml` skeleton wiring train and val `lm` dataloaders.

Memmap pretokenization (`labels.bin`, `prompt_mask.bin`) is intentionally **not** supported. Data flows through `prepare_data` + iterable shards only.

Collator and model experiment wiring are left for a follow-up PR (e.g. `seq2seq_mlm` with `block_size: 512`).

## Test plan

- [ ] `python -m xlm.harness job_type=prepare_data datamodule=tinygsm` (smoke; optional `DEBUG_OVERFIT=1`)
- [ ] After collator is wired in a model experiment: verify prefix/suffix batch shapes and MDM noise on suffix only


Made with [Cursor](https://cursor.com)