### PR TITLE
LLaDA integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ evals/protein_eval/logs/
 .pytest_cache/
 docs/**/linkedin
 .cursor
+# local clone of dhruvdcoder/slurm_scripts (not tracked; was briefly a submodule)
+/slurm_scripts/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "vendor/dplm"]
 	path = vendor/dplm
 	url = https://github.com/bytedance/dplm.git
-[submodule "slurm_scripts"]
-	path = slurm_scripts
-	url = https://github.com/dhruvdcoder/slurm_scripts.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "vendor/dplm"]
 	path = vendor/dplm
 	url = https://github.com/bytedance/dplm.git
+[submodule "slurm_scripts"]
+	path = slurm_scripts
+	url = https://github.com/dhruvdcoder/slurm_scripts.git

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ XLM is a modular framework for developing and comparing non-autoregressive langu
 <details>
 <summary><strong>Model families (papers and docs)</strong></summary>
 
-The companion package [`xlm-models`](https://github.com/dhruvdcoder/xlm-core/tree/main/xlm-models) registers six families (see [`xlm_models.json`](https://github.com/dhruvdcoder/xlm-core/blob/main/xlm-models/xlm_models.json)). Cross-family comparison: [Models overview](https://dhruveshp.com/xlm-core/dev/models/).
+The companion package [`xlm-models`](https://github.com/dhruvdcoder/xlm-core/tree/main/xlm-models) registers seven families (see [`xlm_models.json`](https://github.com/dhruvdcoder/xlm-core/blob/main/xlm-models/xlm_models.json)). Cross-family comparison: [Models overview](https://dhruveshp.com/xlm-core/dev/models/).
 
 | Tag | Name | Docs | State | Paper / notes |
 |-----|------|------|-------|---------------|
@@ -52,6 +52,7 @@ The companion package [`xlm-models`](https://github.com/dhruvdcoder/xlm-core/tre
 | `mlm` | Masked language model (BERT-style) | [Guide](https://dhruveshp.com/xlm-core/dev/models/mlm/) | Beta | — |
 | `flexmdm` | Flexible masked diffusion | [Guide](https://dhruveshp.com/xlm-core/dev/models/flexmdm/) | Alpha | [arXiv:2509.01025](https://arxiv.org/abs/2509.01025) |
 | `dream` | Dream-style decoder LM | Partial | Alpha | [Source](https://github.com/dhruvdcoder/xlm-core/tree/main/xlm-models/dream); backbone in [`xlm.backbones.dream`](https://dhruveshp.com/xlm-core/dev/reference/xlm/backbones/dream/) |
+| `llada` | LLaDA masked diffusion LM | [Guide](https://dhruveshp.com/xlm-core/dev/models/llada/) | Partial / Alpha | [arXiv:2502.09992](https://arxiv.org/abs/2502.09992); [Source](https://github.com/dhruvdcoder/xlm-core/tree/main/xlm-models/llada); backbone in `xlm.backbones.llada` |
 
 </details>
 

--- a/docs/guide/contributing/adding-a-model.md
+++ b/docs/guide/contributing/adding-a-model.md
@@ -2,7 +2,7 @@
 
 This guide covers adding a **first-party** model family under {{ gh_dir('xlm-models', 'xlm-models/') }} in this repository. For a model in a separate repo, see [External models](../external-models.md).
 
-Reference implementations: `arlm`, `ilm`, `mlm`, `mdlm`, `flexmdm`, `dream`. Conceptual comparison: [Models overview](../../models/index.md).
+Reference implementations: `arlm`, `ilm`, `mlm`, `mdlm`, `flexmdm`, `dream`, `llada`. Conceptual comparison: [Models overview](../../models/index.md).
 
 ## Quick start
 

--- a/docs/guide/contributing/core-development.md
+++ b/docs/guide/contributing/core-development.md
@@ -38,7 +38,7 @@ Protocol or harness changes can break any model family — keep `xlm-models` edi
 1. **Search existing [Issues](https://github.com/dhruvdcoder/xlm-core/issues)** and [Discussions](https://github.com/dhruvdcoder/xlm-core/discussions) for overlap.
 2. **Open an issue** for non-trivial work. Use the [feature request template](https://github.com/dhruvdcoder/xlm-core/issues/new?template=feature_request.md) and note which component is affected (core, CLI, metrics, datamodule, etc.).
 3. **Assess impact radius:**
-   - **Protocol changes** (`LossFunction`, `Predictor`, `Collator`, or `Harness` in {{ gh('src/xlm/harness.py', 'harness.py') }} / {{ gh('src/xlm/datamodule.py', 'datamodule.py') }}) affect every family under {{ gh_dir('xlm-models', 'xlm-models/') }} (`arlm`, `ilm`, `mlm`, `mdlm`, `flexmdm`, `dream`) and external models using the same contracts.
+   - **Protocol changes** (`LossFunction`, `Predictor`, `Collator`, or `Harness` in {{ gh('src/xlm/harness.py', 'harness.py') }} / {{ gh('src/xlm/datamodule.py', 'datamodule.py') }}) affect every family under {{ gh_dir('xlm-models', 'xlm-models/') }} (`arlm`, `ilm`, `mlm`, `mdlm`, `flexmdm`, `dream`, `llada`) and external models using the same contracts.
    - **Hydra config changes** (renamed keys, moved defaults under {{ gh_dir('src/xlm/configs', 'configs/') }}) may require updating experiment and datamodule YAMLs across `xlm-models/` and downstream repos.
 4. Skim the closest existing code and the [Related guides](#related-guides) below before proposing API shape.
 

--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -1,6 +1,6 @@
 # Models
 
-Each `xlm-models/<family>/` package implements one language-modeling paradigm against a small set of shared `xlm.*` abstractions. The four families documented here — **ARLM**, **ILM**, **MDLM**, **MLM** — share the same component layout (model, loss, predictor, collator, metrics, types) but differ in what they predict and how they decode.
+Each `xlm-models/<family>/` package implements one language-modeling paradigm against a small set of shared `xlm.*` abstractions. The four families documented in full below — **ARLM**, **ILM**, **MDLM**, **MLM** — share the same component layout (model, loss, predictor, collator, metrics, types) but differ in what they predict and how they decode. **FlexMDM**, **Dream**, and **LLaDA** are additional packages (Alpha / partial); see their pages for the current surface.
 
 ## Shared abstractions
 
@@ -40,6 +40,8 @@ flowchart LR
 | **Per-family doc** | [arlm.md](arlm.md) | [ilm.md](ilm.md) | [mdlm.md](mdlm.md) | [mlm.md](mlm.md) |
 
 **FlexMDM** (variable-length masked diffusion; package {{ gh_dir('xlm-models/flexmdm', 'xlm-models/flexmdm/') }}) is documented separately in [flexmdm.md](flexmdm.md), including the [TinyGSM](flexmdm.md#tinygsm) seq2seq experiment.
+
+**LLaDA** (Hub masked diffusion LM; package {{ gh_dir('xlm-models/llada', 'xlm-models/llada/') }}, backbone {{ gh_dir('src/xlm/backbones/llada', 'src/xlm/backbones/llada/') }}) is documented in [llada.md](llada.md). Eval-focused / Dream-parity (no loss yet); MATH-500 Hub eval via `experiment=math500_llada_eval`.
 
 ## Page layout
 

--- a/docs/models/llada.md
+++ b/docs/models/llada.md
@@ -2,9 +2,9 @@
 
 ## 1. Overview
 
-`llada` integrates [LLaDA](https://arxiv.org/abs/2502.09992) (GSAI-ML) into xLM at **Dream parity**: a Hub-key-compatible backbone, an MLM-protocol adapter, a diffusion predictor, and Hydra eval configs. Training loss / metrics are **not** implemented yet (Alpha / eval-focused), same status as [`dream`](https://github.com/dhruvdcoder/xlm-core/tree/main/xlm-models/dream).
+`llada` integrates GSAI-ML's [LLaDA](https://arxiv.org/abs/2502.09992) into xLM. It provides the same pieces as the [`dream`](https://github.com/dhruvdcoder/xlm-core/tree/main/xlm-models/dream) package: a backbone whose state-dict keys match the Hub checkpoint, an adapter for the MLM predictor protocol, a diffusion predictor, and Hydra configs for evaluation. Like `dream`, it is currently eval-only — training loss and metrics are not implemented yet.
 
-LLaDA is a masked discrete diffusion LM: a bidirectional Transformer predicts tokens at `[MASK]` positions (`mask_token_id=126336`, string `<|mdm_mask|>`). Sampling fills a fixed canvas of masks and commits the most confident predictions per semi-autoregressive block (low-confidence remasking).
+LLaDA is a masked discrete diffusion LM. A bidirectional Transformer predicts tokens at `[MASK]` positions (`mask_token_id=126336`, string `<|mdm_mask|>`). To generate, the sampler starts from a canvas of mask tokens and, over a number of steps, commits the predictions it is most confident about ("low-confidence remasking" in the paper), optionally working left to right in semi-autoregressive blocks.
 
 ```bibtex
 @article{nie2025llada,
@@ -15,12 +15,12 @@ LLaDA is a masked discrete diffusion LM: a bidirectional Transformer predicts to
 }
 ```
 
-Hub checkpoints (same architecture; switch via `hub.repo_id`):
+Both Hub checkpoints share the same architecture, so they use the same model YAML — pick one with `hub.repo_id`:
 
 | Checkpoint | Notes |
 |---|---|
 | [`GSAI-ML/LLaDA-8B-Base`](https://huggingface.co/GSAI-ML/LLaDA-8B-Base) | Default in `math500_llada_eval` |
-| [`GSAI-ML/LLaDA-8B-Instruct`](https://huggingface.co/GSAI-ML/LLaDA-8B-Instruct) | Same model YAML; override `hub.repo_id` + tokenizer path |
+| [`GSAI-ML/LLaDA-8B-Instruct`](https://huggingface.co/GSAI-ML/LLaDA-8B-Instruct) | Override `hub.repo_id` and the tokenizer path (see below) |
 
 Package: {{ gh_dir('xlm-models/llada', 'xlm-models/llada/') }}. Backbone: {{ gh_dir('src/xlm/backbones/llada', 'src/xlm/backbones/llada/') }}.
 
@@ -35,17 +35,15 @@ Package: {{ gh_dir('xlm-models/llada', 'xlm-models/llada/') }}. Backbone: {{ gh_
 | {{ gh('xlm-models/llada/predictor_llada.py', 'predictor_llada.py') }} | `LLaDAPredictor` |
 | {{ gh('xlm-models/llada/datamodule_llada.py', 'datamodule_llada.py') }} | `print_batch_llada` |
 
-No `loss_llada.py` / `metrics_llada.py` yet (eval-only).
+There is no `loss_llada.py` or `metrics_llada.py` yet, since the package is eval-only.
 
 ## 3. Architecture
 
-Ported from the Hub `trust_remote_code` modules with **state-dict keys unchanged**, so weights load with `strict=True` and no remapping:
+The backbone is ported from the Hub `trust_remote_code` modules with state-dict keys left unchanged, so checkpoints load with `strict=True` and no key remapping. The relevant keys are `model.transformer.wte`, `model.transformer.blocks.{i}.{q,k,v,up,ff}_proj`, `model.transformer.ln_f`, and `model.transformer.ff_out` (the head is untied).
 
-`model.transformer.wte`, `model.transformer.blocks.{i}.{q,k,v,up,ff}_proj`, `model.transformer.ln_f`, `model.transformer.ff_out` (untied).
+The 8B layout, taken from the Hub `config.json`: `d_model=4096`, 32 layers, 32 MHA heads, `mlp_hidden_size=12288`, `vocab_size=embedding_size=126464`, RoPE with `rope_theta=500000`, no weight tying, and bidirectional attention (`is_causal=False`).
 
-8B layout (from Hub `config.json`): `d_model=4096`, 32 layers, 32 MHA heads, `mlp_hidden_size=12288`, `vocab_size=embedding_size=126464`, RoPE (`rope_theta=500000`), `weight_tying=false`, bidirectional attention (`is_causal=False` / MDM path).
-
-`LLaDAXLMModel` adapts the HF wrapper to the MLM predictor protocol (same surface as Dream, without a logits shift):
+`LLaDAXLMModel` adapts the HF wrapper to the MLM predictor protocol — the same surface as Dream, minus the logits shift:
 
 ```python
 forward(
@@ -55,7 +53,7 @@ forward(
 ) -> Tensor                                   # (B, L, embedding_size) logits
 ```
 
-Unlike Dream, LLaDA predicts each masked position **in place** — do **not** wire `LogitsShiftBy1`.
+Unlike Dream, LLaDA predicts each masked position in place, so `LogitsShiftBy1` must not be wired in.
 
 ## 4. Batch contract
 
@@ -67,11 +65,11 @@ Eval uses the shared MLM seq2seq prediction collator (`MLMSeq2SeqPredCollator`) 
 | `attention_mask` | `(B, L)` | 1 = real, 0 = pad |
 | `answer` / `target` | pass-through | For `Math500Eval` post-hoc |
 
-Predictor appends `max_new_tokens` of `<|mdm_mask|>` (id `126336`) as the generation canvas.
+The predictor then appends `max_new_tokens` copies of `<|mdm_mask|>` (id `126336`) to the right of the prompt; this is the canvas the sampler fills in.
 
 ## 5. Loss
 
-Not implemented. There is no `loss:` key under `model_type/llada_base.yaml` (Dream-style).
+Not implemented yet. `model_type/llada_base.yaml` has no `loss:` key, following the same convention as Dream.
 
 ## 6. Collators
 
@@ -81,7 +79,7 @@ Not implemented. There is no `loss:` key under `model_type/llada_base.yaml` (Dre
 
 ## 7. Predictor
 
-`LLaDAPredictor` subclasses `DreamPredictor`. Mapping to the LLaDA reference sampler (`generate.py`):
+`LLaDAPredictor` subclasses `DreamPredictor` directly — the Dream machinery already implements LLaDA's sampling procedure, so no new sampling code was needed. The knobs map onto the reference sampler (`generate.py` in the LLaDA repo) as follows:
 
 | LLaDA reference | xLM predictor knobs |
 |---|---|
@@ -92,11 +90,11 @@ Not implemented. There is no `loss:` key under `model_type/llada_base.yaml` (Dre
 | `gen_length` | `max_new_tokens` |
 | `temperature=0` | `temperature: 0.0` (greedy) |
 
-Classifier-free guidance (`cfg_scale`) from the reference code is **not** implemented.
+Classifier-free guidance (`cfg_scale` in the reference code) is not implemented; the reference base-model evals run without it.
 
 ## 8. Metrics
 
-Step-level LM metrics are not wired for LLaDA eval. MATH-500 accuracy comes from the post-hoc evaluator {{ gh('src/xlm/tasks/math500/__init__.py', 'Math500Eval') }} over logged predictions.
+Step-level LM metrics are not wired up for LLaDA eval. MATH-500 accuracy is computed after the run by the post-hoc evaluator {{ gh('src/xlm/tasks/math500/__init__.py', 'Math500Eval') }}, which scores the logged predictions with `math_verify`.
 
 ## 9. Configs / experiments
 
@@ -111,7 +109,7 @@ Hydra configs under {{ gh_dir('xlm-models/llada/configs', 'xlm-models/llada/conf
 | `debug/math500_debug.yaml` | Tiny debug limits |
 | `fsdp/decoder_lm_example.yaml` | Example FSDP grouping for `model.transformer.*` |
 
-Register the package (`xlm_models.json` already lists `"llada": "llada"`). Ensure the editable install / `XLM_MODELS_PACKAGES` can see it:
+The package is registered in `xlm_models.json` (`"llada": "llada"`). Make sure your install can see it:
 
 ```bash
 # from the xlm-core repo root
@@ -128,7 +126,7 @@ xlm job_type=prepare_data job_name=math500_llada_prep \
   experiment=math500_llada_eval num_dataset_workers=4
 ```
 
-Run eval (loads `GSAI-ML/LLaDA-8B-Base` via `hub.repo_id` in the experiment YAML). Use a GPU with enough memory for bf16 8B (~16GB+):
+Then run the eval. Weights are pulled from the Hub (`hub.repo_id` in the experiment YAML, `GSAI-ML/LLaDA-8B-Base` by default); you need a GPU with enough memory for the 8B model in bf16 (~16GB+):
 
 ```bash
 xlm job_type=eval job_name=math500_llada_eval \
@@ -136,7 +134,7 @@ xlm job_type=eval job_name=math500_llada_eval \
   ++trainer.precision=bf16-mixed
 ```
 
-Instruct checkpoint (same model YAML):
+For the Instruct checkpoint, override the repo id and tokenizer path (the model YAML stays the same):
 
 ```bash
 xlm job_type=eval job_name=math500_llada_instruct_eval \
@@ -147,9 +145,9 @@ xlm job_type=eval job_name=math500_llada_instruct_eval \
 ```
 
 !!! note "Hub-only eval and local checkpoints"
-    If `checkpointing_dir` already contains `best.ckpt` / `last.ckpt`, those **override** Hub weights. Use a fresh `job_name` or a clean `checkpointing_dir`. Set `HF_HUB_KEY` (or `.secrets.env`) for Hub download. See [Evaluate](../guide/eval.md).
+    If `checkpointing_dir` already contains `best.ckpt` / `last.ckpt`, those take precedence over Hub weights. Use a fresh `job_name` or a clean `checkpointing_dir` when you want a pure Hub eval. Set `HF_HUB_KEY` (or `.secrets.env`) for the Hub download. See [Evaluate](../guide/eval.md).
 
-Debug smoke (few batches):
+For a quick smoke test that only runs a few batches:
 
 ```bash
 xlm job_type=eval job_name=math500_llada_debug \

--- a/docs/models/llada.md
+++ b/docs/models/llada.md
@@ -1,0 +1,175 @@
+# LLaDA — Large Language Diffusion Model
+
+## 1. Overview
+
+`llada` integrates [LLaDA](https://arxiv.org/abs/2502.09992) (GSAI-ML) into xLM at **Dream parity**: a Hub-key-compatible backbone, an MLM-protocol adapter, a diffusion predictor, and Hydra eval configs. Training loss / metrics are **not** implemented yet (Alpha / eval-focused), same status as [`dream`](https://github.com/dhruvdcoder/xlm-core/tree/main/xlm-models/dream).
+
+LLaDA is a masked discrete diffusion LM: a bidirectional Transformer predicts tokens at `[MASK]` positions (`mask_token_id=126336`, string `<|mdm_mask|>`). Sampling fills a fixed canvas of masks and commits the most confident predictions per semi-autoregressive block (low-confidence remasking).
+
+```bibtex
+@article{nie2025llada,
+  title   = {Large Language Diffusion Models},
+  author  = {Nie, Shen and Zhu, Fengqi and You, Zebin and Zhang, Xiaolu and Ou, Jingyang and Hu, Jun and Zhou, Jun and Lin, Yankai and Wen, Ji-Rong and Li, Chongxuan},
+  journal = {arXiv preprint arXiv:2502.09992},
+  year    = {2025}
+}
+```
+
+Hub checkpoints (same architecture; switch via `hub.repo_id`):
+
+| Checkpoint | Notes |
+|---|---|
+| [`GSAI-ML/LLaDA-8B-Base`](https://huggingface.co/GSAI-ML/LLaDA-8B-Base) | Default in `math500_llada_eval` |
+| [`GSAI-ML/LLaDA-8B-Instruct`](https://huggingface.co/GSAI-ML/LLaDA-8B-Instruct) | Same model YAML; override `hub.repo_id` + tokenizer path |
+
+Package: {{ gh_dir('xlm-models/llada', 'xlm-models/llada/') }}. Backbone: {{ gh_dir('src/xlm/backbones/llada', 'src/xlm/backbones/llada/') }}.
+
+## 2. Files at a glance
+
+| Module | Public classes / helpers |
+|---|---|
+| {{ gh('src/xlm/backbones/llada/configuration_llada.py', 'configuration_llada.py') }} | `LLaDAConfigBase`, `ModelConfig`, enums |
+| {{ gh('src/xlm/backbones/llada/modeling_llada.py', 'modeling_llada.py') }} | `LLaDAModel`, `LLaDAModelLM`, `LLaDALlamaBlock`, … |
+| {{ gh('xlm-models/llada/configuration_llada.py', 'llada/configuration_llada.py') }} | `LLaDAConfig` |
+| {{ gh('xlm-models/llada/llada_model.py', 'llada_model.py') }} | `LLaDAHFModel`, `LLaDAXLMModel` |
+| {{ gh('xlm-models/llada/predictor_llada.py', 'predictor_llada.py') }} | `LLaDAPredictor` |
+| {{ gh('xlm-models/llada/datamodule_llada.py', 'datamodule_llada.py') }} | `print_batch_llada` |
+
+No `loss_llada.py` / `metrics_llada.py` yet (eval-only).
+
+## 3. Architecture
+
+Ported from the Hub `trust_remote_code` modules with **state-dict keys unchanged**, so weights load with `strict=True` and no remapping:
+
+`model.transformer.wte`, `model.transformer.blocks.{i}.{q,k,v,up,ff}_proj`, `model.transformer.ln_f`, `model.transformer.ff_out` (untied).
+
+8B layout (from Hub `config.json`): `d_model=4096`, 32 layers, 32 MHA heads, `mlp_hidden_size=12288`, `vocab_size=embedding_size=126464`, RoPE (`rope_theta=500000`), `weight_tying=false`, bidirectional attention (`is_causal=False` / MDM path).
+
+`LLaDAXLMModel` adapts the HF wrapper to the MLM predictor protocol (same surface as Dream, without a logits shift):
+
+```python
+forward(
+    x_t: Tensor,                              # (B, L) input ids
+    attention_mask: Optional[Tensor] = None,  # 2D pad mask (native LLaDA path)
+    positions: Optional[Tensor] = None,       # RoPE position_ids (packed cumsum OK)
+) -> Tensor                                   # (B, L, embedding_size) logits
+```
+
+Unlike Dream, LLaDA predicts each masked position **in place** — do **not** wire `LogitsShiftBy1`.
+
+## 4. Batch contract
+
+Eval uses the shared MLM seq2seq prediction collator (`MLMSeq2SeqPredCollator`) with MATH-500 fields:
+
+| Field | Shape | Notes |
+|---|---|---|
+| `input_ids` | `(B, L)` | Left-padded prompt |
+| `attention_mask` | `(B, L)` | 1 = real, 0 = pad |
+| `answer` / `target` | pass-through | For `Math500Eval` post-hoc |
+
+Predictor appends `max_new_tokens` of `<|mdm_mask|>` (id `126336`) as the generation canvas.
+
+## 5. Loss
+
+Not implemented. There is no `loss:` key under `model_type/llada_base.yaml` (Dream-style).
+
+## 6. Collators
+
+| Config | Class | Role |
+|---|---|---|
+| {{ gh('xlm-models/llada/configs/collator/math500_pred_llada.yaml', 'math500_pred_llada') }} | `mlm.datamodule_mlm.MLMSeq2SeqPredCollator` | MATH-500 prompt → prediction batch |
+
+## 7. Predictor
+
+`LLaDAPredictor` subclasses `DreamPredictor`. Mapping to the LLaDA reference sampler (`generate.py`):
+
+| LLaDA reference | xLM predictor knobs |
+|---|---|
+| `remasking='low_confidence'` | `confidence: top_prob` |
+| `remasking='random'` | `confidence: null` |
+| `block_length` | `block_size` (semi-AR blocks) |
+| `steps` | `max_steps` |
+| `gen_length` | `max_new_tokens` |
+| `temperature=0` | `temperature: 0.0` (greedy) |
+
+Classifier-free guidance (`cfg_scale`) from the reference code is **not** implemented.
+
+## 8. Metrics
+
+Step-level LM metrics are not wired for LLaDA eval. MATH-500 accuracy comes from the post-hoc evaluator {{ gh('src/xlm/tasks/math500/__init__.py', 'Math500Eval') }} over logged predictions.
+
+## 9. Configs / experiments
+
+Hydra configs under {{ gh_dir('xlm-models/llada/configs', 'xlm-models/llada/configs/') }}:
+
+| Config | Role |
+|---|---|
+| `model/llada_8b.yaml` | Architecture (Base and Instruct share this file) |
+| `model_type/llada_base.yaml` / `llada_eval.yaml` | Harness + predictor (no loss) |
+| `experiment/math500_llada_eval.yaml` | MATH-500 Hub eval |
+| `datamodule/math500_llada.yaml` | Prediction dataloaders + `print_batch_llada` |
+| `debug/math500_debug.yaml` | Tiny debug limits |
+| `fsdp/decoder_lm_example.yaml` | Example FSDP grouping for `model.transformer.*` |
+
+Register the package (`xlm_models.json` already lists `"llada": "llada"`). Ensure the editable install / `XLM_MODELS_PACKAGES` can see it:
+
+```bash
+# from the xlm-core repo root
+pip install -e ./xlm-models
+# or: export XLM_MODELS_PACKAGES=mlm:dream:llada
+```
+
+### MATH-500 eval (Hub weights)
+
+Prepare the MATH-500 cache once (rank 0):
+
+```bash
+xlm job_type=prepare_data job_name=math500_llada_prep \
+  experiment=math500_llada_eval num_dataset_workers=4
+```
+
+Run eval (loads `GSAI-ML/LLaDA-8B-Base` via `hub.repo_id` in the experiment YAML). Use a GPU with enough memory for bf16 8B (~16GB+):
+
+```bash
+xlm job_type=eval job_name=math500_llada_eval \
+  experiment=math500_llada_eval \
+  ++trainer.precision=bf16-mixed
+```
+
+Instruct checkpoint (same model YAML):
+
+```bash
+xlm job_type=eval job_name=math500_llada_instruct_eval \
+  experiment=math500_llada_eval \
+  hub.repo_id=GSAI-ML/LLaDA-8B-Instruct \
+  global_components.tokenizer.pretrained_model_name_or_path=GSAI-ML/LLaDA-8B-Instruct \
+  ++trainer.precision=bf16-mixed
+```
+
+!!! note "Hub-only eval and local checkpoints"
+    If `checkpointing_dir` already contains `best.ckpt` / `last.ckpt`, those **override** Hub weights. Use a fresh `job_name` or a clean `checkpointing_dir`. Set `HF_HUB_KEY` (or `.secrets.env`) for Hub download. See [Evaluate](../guide/eval.md).
+
+Debug smoke (few batches):
+
+```bash
+xlm job_type=eval job_name=math500_llada_debug \
+  experiment=math500_llada_eval debug=math500_debug \
+  ++trainer.precision=bf16-mixed
+```
+
+## 10. Testing
+
+{{ gh_dir('tests/models/llada', 'tests/models/llada/') }}:
+
+```bash
+# CPU unit tests (tiny config)
+pytest tests/models/llada/test_llada_model.py -q
+
+# Full 8B Hub logits parity vs AutoModel(trust_remote_code=True)
+XLM_RUN_HUB_TESTS=1 pytest tests/models/llada/test_llada_model.py -k hub
+```
+
+## 11. API reference
+
+- Backbone: {{ gh_dir('src/xlm/backbones/llada', 'xlm.backbones.llada') }}
+- Package: {{ gh_dir('xlm-models/llada', 'llada') }}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,7 @@ nav:
       - ARLM: models/arlm.md
       - FlexMDM: models/flexmdm.md
       - ILM: models/ilm.md
+      - LLaDA: models/llada.md
       - MDLM: models/mdlm.md
       - MLM: models/mlm.md
 

--- a/src/xlm/backbones/llada/__init__.py
+++ b/src/xlm/backbones/llada/__init__.py
@@ -1,0 +1,26 @@
+"""LLaDA-family backbone (modeling + LLaDAConfigBase).
+
+Ported from the ``GSAI-ML/LLaDA-8B-Base`` Hub repo with state-dict keys kept
+identical to the checkpoint (strict load, no remapping). The tokenizer is a
+stock ``PreTrainedTokenizerFast``; load it via
+``xlm.datamodule.load_auto_tokenizer`` (no custom tokenizer class needed).
+"""
+
+from xlm.backbones.llada.configuration_llada import LLaDAConfigBase, ModelConfig
+from xlm.backbones.llada.modeling_llada import (
+    LLaDABlock,
+    LLaDALlamaBlock,
+    LLaDAModel,
+    LLaDAModelLM,
+    LLaDASequentialBlock,
+)
+
+__all__ = [
+    "LLaDAConfigBase",
+    "ModelConfig",
+    "LLaDABlock",
+    "LLaDALlamaBlock",
+    "LLaDASequentialBlock",
+    "LLaDAModel",
+    "LLaDAModelLM",
+]

--- a/src/xlm/backbones/llada/configuration_llada.py
+++ b/src/xlm/backbones/llada/configuration_llada.py
@@ -1,0 +1,476 @@
+"""
+LLaDA configuration.
+
+Ported from the ``GSAI-ML/LLaDA-8B-Base`` Hub repo (``configuration_llada.py``,
+``trust_remote_code`` module). Changes vs upstream:
+
+- ``LLaDAConfig`` renamed to ``LLaDAConfigBase`` (variant configs subclass it in
+  ``xlm-models/llada``), mirroring ``DreamConfigBase``.
+- No ``AutoConfig.register`` call: registration would clash with the remote-code
+  module when both are imported in one process (e.g. checkpoint-parity tests).
+"""
+from transformers import PretrainedConfig
+
+from enum import Enum
+from os import PathLike
+from typing import Union
+from dataclasses import asdict, dataclass, field, fields as dataclass_fields
+from glob import glob
+from pathlib import Path
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+)
+
+
+__all__ = [
+    "ActivationType",
+    "ActivationCheckpointingStrategy",
+    "BlockType",
+    "LayerNormType",
+    "InitFnType",
+    "ModelConfig",
+    "LLaDAConfigBase",
+]
+
+PathOrStr = Union[str, PathLike]
+
+
+class StrEnum(str, Enum):
+    """
+    This is equivalent to Python's :class:`enum.StrEnum` since version 3.11.
+    We include this here for compatibility with older version of Python.
+    """
+
+    def __str__(self) -> str:
+        return self.value
+
+    def __repr__(self) -> str:
+        return f"'{str(self)}'"
+
+
+class LayerNormType(StrEnum):
+    default = "default"
+    """
+    The default LayerNorm implementation, equivalent to PyTorch's built-in version.
+    """
+
+    low_precision = "low_precision"
+    """
+    A low-precision version of the default LayerNorm.
+    """
+
+    rms = "rms"
+    """
+    An RMSNorm implementation. When using ``torch.compile`` this is
+    probably the fastest implementation.
+    """
+
+    gemma_rms = "gemma_rms"
+    """
+    An RMSNorm implementation by gemmma. When using ``torch.compile`` this is
+    probably the fastest implementation.
+    """
+
+    amd_compatible = "amd_compatible"
+    """
+    LayerNorm implemented manually to work around an issue with ROCm.
+    """
+
+
+class ActivationType(StrEnum):
+    gelu = "gelu"
+    relu = "relu"
+    silu = "silu"
+    swiglu = "swiglu"
+
+
+class BlockType(StrEnum):
+    sequential = "sequential"
+    parallel = "parallel"
+
+    llama = "llama"
+    """
+    A block similar to the sequential block with slightly different
+    implementations of operations like attention to imitate the behavior of Llama.
+    """
+
+
+class InitFnType(StrEnum):
+    mitchell = "mitchell"
+    """
+    The strategy suggested to us by Mitchell Wortsman from UW.
+    This uses a truncated normal distribution with an adaptive standard deviation that depends
+    on the size of the weights as well as the depth of the layer.
+    """
+
+    normal = "normal"
+    """
+    All weights are initialized from the same normal distribution.
+    """
+
+    kaiming_normal = "kaiming_normal"
+    """
+    All weights are initialized with the Kaiming method from a normal distribution.
+    Note this currently won't work with FSDP.
+    """
+
+    fan_in = "fan_in"
+    """
+    "Fan-in variance scaling", i.e. normal with a standard deviation of ``1/sqrt(d_in)`` where ``d_in``
+    is the input dimensionality of the kernel.
+    """
+
+    full_megatron = "full_megatron"
+    """
+    This is what metaseq calls "full megatron init". It is the init used for Llama 2.
+    """
+
+
+@dataclass
+class ModelConfig():
+    """
+    LLaDA (model) configuration.
+    """
+
+    # Note that the defaults for these attributes are equivalent to the base GPT2 model.
+
+    d_model: int = 768
+    """
+    The hidden size of the model.
+    """
+
+    n_heads: int = 12
+    """
+    The number of self-attention heads.
+    """
+
+    n_kv_heads: Optional[int] = None
+    """
+    The number of heads to use for keys and values. Defaults to `n_heads`.
+    Set this to ``None`` or ``n_heads`` for normal multi-head attention.
+    Set this to 1 for multi-query attention.
+    Set it to some in-between value for Llama2-style grouped query attention.
+    """
+
+    n_layers: int = 12
+    """
+    The number of layers/blocks.
+    """
+
+    mlp_ratio: int = 4
+    """
+    The ratio of the inner MLP dimensionality to ``d_model``.
+    This is only used when ``mlp_hidden_size`` is not set.
+    """
+
+    mlp_hidden_size: Optional[int] = None
+    """
+    Set the exact hidden size for the MLP. Otherwise the inner MLP hidden size will be set to `mlp_ratio * d_model`.
+    """
+
+    activation_type: ActivationType = ActivationType.swiglu
+    """
+    The activation function to use within the MLP layers.
+    """
+
+    block_type: BlockType = BlockType.sequential
+    """
+    The transformer block implementation.
+    """
+
+    block_group_size: int = 1
+    """
+    The number of blocks to group together into a single parent block.
+    This has no affect on the number of parameters in the model and is only used to wrap groups
+    of blocks together with a single FSDP wrapper during training.
+    """
+
+    alibi: bool = False
+    """
+    If ``True``, use ALiBi embeddings. Mutually exclusive with ``rope``.
+    """
+
+    alibi_bias_max: float = 8.0
+    """
+    Maximum absolute value of ALiBi bias.
+    """
+
+    rope: bool = False
+    """
+    Use rotary positional embeddings (RoPE). Mutually exclusive with ``alibi``.
+    """
+
+    rope_full_precision: bool = True
+    """
+    If ``True``, apply RoPE embeddings at full precision regardless of the input type. Otherwise,
+    apply RoPE at the precision of the input.
+    """
+
+    flash_attention: bool = False
+    """
+    If ``True``, use ``FlashAttention``.
+    """
+
+    attention_dropout: float = 0.1
+    """
+    The dropout probability within the attention modules.
+    """
+
+    multi_query_attention: Optional[bool] = None
+    """
+    Use the Multi-Query formulation of attention used in PaLM. This reduces the number of parameters
+    and is more efficient during inference.
+    """
+
+    attention_layer_norm: bool = False
+    """
+    Apply layer norm to the keys and queries within the attention mechanism.
+    This can help stabilize training.
+    """
+
+    residual_dropout: float = 0.1
+    """
+    The dropout probability for the MLP and attention output within each block.
+    """
+
+    embedding_dropout: float = 0.1
+    """
+    The dropout probability for embeddings.
+    """
+
+    input_emb_norm: bool = False
+    """
+    An input hidden_states norm implementation by gemmma.
+    """
+
+    layer_norm_type: LayerNormType = LayerNormType.default
+    """
+    The layernorm implementation to use.
+    """
+
+    layer_norm_with_affine: bool = True
+    """
+    Whether to include bias and weight parameters for the layer norms.
+    This only affects layer norms that are immediately followed by a linear layer in the forward pass,
+    so everything except QK-norms. To turn off affines for QK norms as well, set :attr:`attention_layer_norm_with_affine`
+    to ``False``.
+    """
+
+    rms_norm_eps: float = 1e-05
+    """
+    The rms layernorm eps param.
+    """
+
+    attention_layer_norm_with_affine: bool = True
+    """
+    Toggle affine transform for the QK norms.
+    """
+
+    max_sequence_length: int = 1024
+    """
+    The maximum input sequence length supported by the model.
+    """
+
+    rope_theta: float = 10000.0
+    """
+    The rope base param.
+    """
+
+    include_qkv_bias: Optional[bool] = False
+    """
+    Whether or not to include bias parameters in qkv linear layers.
+    """
+
+    include_bias: bool = False
+    """
+    Whether or not to include bias parameters in linear layers.
+    In PaLM, they got rid of all bias terms because they found that large
+    models tend to have near 0 bias terms anyway.
+    """
+
+    bias_for_layer_norm: Optional[bool] = None
+    """
+    Whether or not to include bias parameters in layer norm.
+    This is separate from the include_bias parameter, because of a ROCm crash when biases are disabled in
+    layer norm.
+    When this is None (the default), it inherits the setting from include_bias.
+    """
+
+    scale_logits: bool = False
+    """
+    If ``True``, scale the output logits by ``1 / sqrt(d_model)``.
+    """
+
+    vocab_size: int = 50257
+    """
+    Vocabulary size of the model.
+    """
+
+    embedding_size: Optional[int] = 50304
+    """
+    The number of embeddings, i.e. the number of tokens. If set to ``None`` it will default
+    to ``vocab_size``. If ``vocab_size`` is not a multiple of 128, setting this to the
+    next multiple of 128 that's greater than ``vocab_size`` can improve throughput
+    substantially.
+    """
+
+    weight_tying: bool = True
+    """
+    Whether to tie output linear weights to the input embedding.
+    """
+
+    eos_token_id: int = 50256
+    """
+    The ID of the end-of-sentence special token.
+    """
+
+    pad_token_id: int = 50256
+    """
+    The ID of the token to use for padding. Defaults to the ID of the EOS token.
+    """
+
+    mask_token_id: Optional[int] = 50256
+    """
+    The ID of the token to use for mask token. Defaults to the ID of the EOS token.
+    """
+
+    init_device: Optional[str] = None
+    """
+    The torch device to use when initializing the model parameters, e.g. "cpu", "cuda:0", "meta".
+    """
+
+    init_fn: InitFnType = InitFnType.normal
+    """
+    The weight initialization strategy.
+    """
+
+    init_std: float = 0.02
+    """
+    The standard deviation to use when initializing weights with a "fixed distribution" ``init_fn``, such
+    as "normal".
+    """
+
+    init_cutoff_factor: Optional[float] = None
+    """
+    A positive factor used to scale the cutoff values when initializing weights with a "fixed distribution" ``init_fn``, such
+    as "normal". Setting this to None means values are not cutoff.
+    """
+
+    precision: Optional[str] = None
+    """
+    Precision used to train/evaluate with. You shouldn't set this directly.
+    See :data:`TrainConfig.precision` instead.
+    """
+
+    @property
+    def effective_n_kv_heads(self) -> int:
+        if self.n_kv_heads is None:
+            if self.multi_query_attention is True:
+                return 1
+            else:
+                return self.n_heads
+        else:
+            if self.multi_query_attention is None:
+                return self.n_kv_heads
+            if self.multi_query_attention:
+                n_kv_heads_should_be = 1
+            else:
+                n_kv_heads_should_be = self.n_heads
+            if self.n_kv_heads == n_kv_heads_should_be:
+                return n_kv_heads_should_be
+            else:
+                raise Exception(
+                    "You can't set `multi_query_attention` and `n_kv_heads` at the same time."
+                )
+
+class ActivationCheckpointingStrategy(StrEnum):
+    whole_layer = "whole_layer"
+    """
+    Checkpoint every transformer layer.
+    """
+
+    one_in_two = "one_in_two"
+    """
+    Checkpoint one in two transformer layers.
+    """
+
+    one_in_three = "one_in_three"
+    """
+    Checkpoint one in three transformer layers.
+    """
+
+    one_in_four = "one_in_four"
+    """
+    Checkpoint one in four transformer layers.
+    """
+    
+    two_in_three = "two_in_three"
+    """
+    Checkpoint two out of every three transformer layers.
+    """
+
+    three_in_four = "three_in_four"
+    """
+    Checkpoint three out of four of every transformer layers.
+    """
+
+    four_in_five = "four_in_five"
+    """
+    Checkpoint four out of five of every transformer layers.
+    """
+
+    nine_in_ten = "nine_in_ten"
+    """
+    Checkpoint nine out of ten of every transformer layers.
+    """
+
+    fine_grained = "fine_grained"
+    """
+    Focus checkpointing on where it is cheap to recompute and saves most memory.
+    """
+
+
+class LLaDAConfigBase(PretrainedConfig):
+    model_type = "llada"
+    keys_to_ignore_at_inference = ["past_key_values"]  # TODO: confirm
+
+    def __init__(self, use_cache: bool = False, **kwargs):
+        model_config = ModelConfig()
+        all_kwargs = model_config.__dict__
+        all_kwargs.update(kwargs)
+        all_kwargs.update({"use_cache": use_cache})
+        all_kwargs.update(
+            {
+                "architectures": all_kwargs.get("architectures", ["LLaDAModelLM"])
+            }
+        )
+        super().__init__(**all_kwargs)
+        # transformers >= 5 drops some kwargs (e.g. ``use_cache``, None-valued
+        # fields such as ``n_kv_heads``) instead of persisting them as
+        # attributes. Set every ModelConfig field explicitly so
+        # ``create_model_config_from_pretrained_config`` can round-trip.
+        for f in dataclass_fields(ModelConfig):
+            if not hasattr(self, f.name):
+                setattr(self, f.name, all_kwargs[f.name])
+        self.use_cache = use_cache
+
+    @property
+    def num_attention_heads(self):
+        return self.n_heads
+
+    @property
+    def num_hidden_layers(self):
+        return self.n_layers
+
+    @property
+    def hidden_size(self):
+        return self.d_model

--- a/src/xlm/backbones/llada/modeling_llada.py
+++ b/src/xlm/backbones/llada/modeling_llada.py
@@ -1,0 +1,1601 @@
+"""LLaDA modeling (OLMo-style bidirectional decoder).
+
+Ported from the ``GSAI-ML/LLaDA-8B-Base`` Hub repo (``modeling_llada.py``,
+``trust_remote_code`` module). Module/parameter names are kept identical to the
+checkpoint so Hub weights load with ``strict=True`` and zero remapping
+(``model.transformer.wte``, ``model.transformer.blocks.*``,
+``model.transformer.ln_f``, ``model.transformer.ff_out``).
+
+Changes vs upstream (none affect state-dict keys):
+
+- imports from ``.configuration_llada`` use ``LLaDAConfigBase`` (renamed from
+  the upstream ``LLaDAConfig``; variant configs subclass it in
+  ``xlm-models/llada``).
+- optional ``position_ids`` threaded through ``LLaDAModelLM.forward`` ->
+  ``LLaDAModel.forward`` -> blocks -> ``RotaryEmbedding`` so per-token RoPE
+  positions (e.g. packed ``positions`` from an attention-mask cumsum) are
+  supported, mirroring what the Dream backbone offers.
+- no ``AutoModel.register`` call (would clash with the remote-code module when
+  both are imported in one process).
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import sys
+from abc import abstractmethod
+from collections import defaultdict
+from functools import partial
+from typing import (
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    cast,
+)
+from dataclasses import fields
+from typing import List, Optional, Tuple, Union
+
+import torch
+import torch.backends.cuda
+import torch.nn as nn
+import torch.nn.functional as F
+from torch import einsum
+from transformers import PreTrainedModel
+from transformers.modeling_outputs import CausalLMOutputWithPast
+from transformers.cache_utils import Cache
+
+from .configuration_llada import (
+    LLaDAConfigBase,
+    StrEnum,
+    InitFnType,
+    ActivationType,
+    BlockType,
+    LayerNormType,
+    ModelConfig,
+    ActivationCheckpointingStrategy,
+)
+
+if sys.version_info.minor > 8:
+    from collections.abc import MutableMapping
+elif sys.version_info.minor == 8:
+    from typing import MutableMapping
+else:
+    raise SystemExit("This script supports Python 3.8 or higher")
+
+__all__ = [
+    "LayerNormBase",
+    "LayerNorm",
+    "RMSLayerNorm",
+    "GemmaRMSLayerNorm",
+    "RotaryEmbedding",
+    "Activation",
+    "GELU",
+    "ReLU",
+    "SwiGLU",
+    "LLaDABlock",
+    "LLaDASequentialBlock",
+    "LLaDALlamaBlock",
+    "LLaDAModel",
+    "LLaDAModelLM",
+    "LLaDAOutput",
+    "LLaDAGenerateOutput",
+]
+
+
+log = logging.getLogger(__name__)
+
+
+class ModuleType(StrEnum):
+    in_module = "in"
+    out_module = "out"
+    emb = "emb"
+    final_out = "final_out"
+
+
+def init_weights(
+    config: ModelConfig,
+    module: Union[nn.Linear, nn.Embedding],
+    d: Optional[int] = None,
+    layer_id: Optional[int] = None,
+    std_factor: float = 1.0,
+    type_of_module: Optional[ModuleType] = None,
+) -> None:
+    """
+    Initialize weights of a linear or embedding module.
+
+    :param config: The model config.
+    :param module: The linear or embedding submodule to initialize.
+    :param d: The effective input dimensionality of the weights. This could be smaller than the actual dimensions
+        for fused layers.
+    :param layer_id: When set, the standard deviation for the "mitchell" method will be adjusted by
+        ``1 / sqrt(2 * (layer_id + 1))``.
+    """
+    d = d if d is not None else config.d_model
+    if config.init_fn == InitFnType.normal:
+        std = config.init_std * std_factor
+        if config.init_cutoff_factor is not None:
+            cutoff_value = config.init_cutoff_factor * std
+            nn.init.trunc_normal_(module.weight, mean=0.0, std=std, a=-cutoff_value, b=cutoff_value)
+        else:
+            nn.init.normal_(module.weight, mean=0.0, std=std)
+    elif config.init_fn == InitFnType.mitchell:
+        std = std_factor / math.sqrt(d)
+        if layer_id is not None:
+            std = std / math.sqrt(2 * (layer_id + 1))
+        nn.init.trunc_normal_(module.weight, mean=0.0, std=std, a=-3 * std, b=3 * std)
+    elif config.init_fn == InitFnType.kaiming_normal:
+        nn.init.kaiming_normal_(module.weight, nonlinearity="relu")
+    elif config.init_fn == InitFnType.fan_in:
+        std = std_factor / math.sqrt(d)
+        nn.init.normal_(module.weight, mean=0.0, std=std)
+    elif config.init_fn == InitFnType.full_megatron:
+        if type_of_module is None:
+            raise RuntimeError(f"When using the {InitFnType.full_megatron} init, every module must have a type.")
+
+        cutoff_factor = config.init_cutoff_factor
+        if cutoff_factor is None:
+            cutoff_factor = 3
+
+        if type_of_module == ModuleType.in_module:
+            # for att_proj (same as QKV), ff_proj
+            std = config.init_std
+        elif type_of_module == ModuleType.out_module:
+            # for attn_out, ff_out
+            std = config.init_std / math.sqrt(2.0 * config.n_layers)
+        elif type_of_module == ModuleType.emb:
+            # positional embeddings (wpe)
+            # token embeddings (wte)
+            std = config.init_std
+        elif type_of_module == ModuleType.final_out:
+            # final output (ff_out)
+            std = config.d_model**-0.5
+        else:
+            raise RuntimeError(f"Unknown module type '{type_of_module}'")
+        nn.init.trunc_normal_(
+            module.weight,
+            mean=0.0,
+            std=std,
+            a=-cutoff_factor * std,
+            b=cutoff_factor * std,
+        )
+    else:
+        raise NotImplementedError(config.init_fn)
+
+    if isinstance(module, nn.Linear):
+        if module.bias is not None:
+            nn.init.zeros_(module.bias)
+
+        if config.init_fn == InitFnType.normal and getattr(module, "_is_residual", False):
+            with torch.no_grad():
+                module.weight.div_(math.sqrt(2 * config.n_layers))
+
+
+def ensure_finite_(x: torch.Tensor, check_neg_inf: bool = True, check_pos_inf: bool = False):
+    """
+    Modify ``x`` in place to replace ``float("-inf")`` with the minimum value of the dtype when ``check_neg_inf``
+    is ``True`` and to replace ``float("inf")`` with the maximum value of the dtype when ``check_pos_inf`` is ``True``.
+    """
+    if check_neg_inf:
+        x.masked_fill_(x == float("-inf"), torch.finfo(x.dtype).min)
+    if check_pos_inf:
+        x.masked_fill_(x == float("inf"), torch.finfo(x.dtype).max)
+
+
+def activation_checkpoint_function(cfg: ModelConfig):
+    preserve_rng_state = (
+        (cfg.attention_dropout == 0.0) and (cfg.embedding_dropout == 0.0) and (cfg.residual_dropout == 0.0)
+    )
+    from torch.utils.checkpoint import checkpoint
+
+    return partial(
+        checkpoint,
+        preserve_rng_state=preserve_rng_state,
+        use_reentrant=False,
+    )
+
+
+class BufferCache(dict, MutableMapping[str, torch.Tensor]):
+    """
+    Cache for attention biases and other things that would normally be stored as buffers.
+    We avoid using buffers because we've run into various issues doing so with FSDP.
+    In general it appears the way FSDP handles buffers is not well-defined.
+    It doesn't shard them but apparently it does synchronize them across processes, which we want to avoid
+    since (A) it isn't necessary, and (B) we sometimes have `-inf` in these biases which might get turned into
+    NaNs when they're synchronized due to casting or some other issue.
+    """
+
+
+def _non_meta_init_device(config: ModelConfig) -> torch.device:
+    if config.init_device is not None and config.init_device != "meta":
+        return torch.device(config.init_device)
+    else:
+        return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+class Dropout(nn.Dropout):
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        if self.p == 0.0:
+            return input
+        else:
+            return F.dropout(input, self.p, self.training, self.inplace)
+
+
+class LayerNormBase(nn.Module):
+    def __init__(
+        self,
+        config: ModelConfig,
+        *,
+        size: Optional[int] = None,
+        elementwise_affine: Optional[bool] = True,
+        eps: float = 1e-05,
+    ):
+        super().__init__()
+        self.config = config
+        self.eps = eps
+        self.normalized_shape = (size or config.d_model,)
+        if elementwise_affine or (elementwise_affine is None and self.config.layer_norm_with_affine):
+            self.weight = nn.Parameter(torch.ones(self.normalized_shape, device=config.init_device))
+            use_bias = self.config.bias_for_layer_norm
+            if use_bias is None:
+                use_bias = self.config.include_bias
+            if use_bias:
+                self.bias = nn.Parameter(torch.zeros(self.normalized_shape, device=config.init_device))
+            else:
+                self.register_parameter("bias", None)
+        else:
+            self.register_parameter("bias", None)
+            self.register_parameter("weight", None)
+
+    @abstractmethod
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError
+
+    @classmethod
+    def build(cls, config: ModelConfig, size: Optional[int] = None, **kwargs) -> LayerNormBase:
+        if config.layer_norm_type == LayerNormType.default:
+            return LayerNorm(config, size=size, low_precision=False, **kwargs)
+        elif config.layer_norm_type == LayerNormType.low_precision:
+            return LayerNorm(config, size=size, low_precision=True, **kwargs)
+        elif config.layer_norm_type == LayerNormType.rms:
+            return RMSLayerNorm(config, size=size, **kwargs)
+        elif config.layer_norm_type == LayerNormType.gemma_rms:
+            return GemmaRMSLayerNorm(config, size=size, **kwargs)
+        else:
+            raise NotImplementedError(f"Unknown LayerNorm type: '{config.layer_norm_type}'")
+
+    def _cast_if_autocast_enabled(self, tensor: torch.Tensor, dtype: Optional[torch.dtype] = None) -> torch.Tensor:
+        # NOTE: `is_autocast_enabled()` only checks for CUDA autocast, so we use the separate function
+        # `is_autocast_cpu_enabled()` for CPU autocast.
+        # See https://github.com/pytorch/pytorch/issues/110966.
+        if tensor.device.type == "cuda" and torch.is_autocast_enabled():
+            return tensor.to(dtype=dtype if dtype is not None else torch.get_autocast_gpu_dtype())
+        elif tensor.device.type == "cpu" and torch.is_autocast_cpu_enabled():
+            return tensor.to(dtype=dtype if dtype is not None else torch.get_autocast_cpu_dtype())
+        else:
+            return tensor
+
+    def reset_parameters(self):
+        if self.weight is not None:
+            torch.nn.init.ones_(self.weight)  # type: ignore
+        if self.bias is not None:
+            torch.nn.init.zeros_(self.bias)  # type: ignore
+
+
+class LayerNorm(LayerNormBase):
+    """
+    The default :class:`LayerNorm` implementation which can optionally run in low precision.
+    """
+
+    def __init__(
+        self,
+        config: ModelConfig,
+        size: Optional[int] = None,
+        low_precision: bool = False,
+        elementwise_affine: Optional[bool] = None,
+        eps: float = 1e-05,
+    ):
+        super().__init__(config, size=size, elementwise_affine=elementwise_affine, eps=eps)
+        self.low_precision = low_precision
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.low_precision:
+            module_device = x.device
+            downcast_x = self._cast_if_autocast_enabled(x)
+            downcast_weight = (
+                self._cast_if_autocast_enabled(self.weight) if self.weight is not None else self.weight
+            )
+            downcast_bias = self._cast_if_autocast_enabled(self.bias) if self.bias is not None else self.bias
+            with torch.autocast(enabled=False, device_type=module_device.type):
+                return F.layer_norm(
+                    downcast_x, self.normalized_shape, weight=downcast_weight, bias=downcast_bias, eps=self.eps
+                )
+        else:
+            return F.layer_norm(x, self.normalized_shape, weight=self.weight, bias=self.bias, eps=self.eps)
+
+
+class RMSLayerNorm(LayerNormBase):
+    """
+    RMS layer norm, a simplified :class:`LayerNorm` implementation
+    """
+
+    def __init__(
+        self,
+        config: ModelConfig,
+        size: Optional[int] = None,
+        elementwise_affine: Optional[bool] = None,
+        eps: float = 1e-5,
+    ):
+        super().__init__(config, size=size, elementwise_affine=elementwise_affine, eps=config.rms_norm_eps)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        with torch.autocast(enabled=False, device_type=x.device.type):
+            og_dtype = x.dtype
+            x = x.to(torch.float32)
+            variance = x.pow(2).mean(-1, keepdim=True)
+            x = x * torch.rsqrt(variance + self.eps)
+            x = x.to(og_dtype)
+
+        if self.weight is not None:
+            if self.bias is not None:
+                return self.weight * x + self.bias
+            else:
+                return self.weight * x
+        else:
+            return x
+
+
+class GemmaRMSLayerNorm(LayerNormBase):
+    """
+    Gemma RMS layer norm, a simplified :class:`LayerNorm` implementation
+    """
+
+    def __init__(
+        self,
+        config: ModelConfig,
+        size: Optional[int] = None,
+        elementwise_affine: Optional[bool] = None,
+        eps: float = 1e-5,
+    ):
+        super().__init__(config, size=size, elementwise_affine=elementwise_affine, eps=config.rms_norm_eps)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        with torch.autocast(enabled=False, device_type=x.device.type):
+            og_dtype = x.dtype
+            x = x.to(torch.float32)
+            variance = x.pow(2).mean(-1, keepdim=True)
+            x = x * torch.rsqrt(variance + self.eps)
+            x = x.to(og_dtype)
+
+        if self.weight is not None:
+            if self.bias is not None:
+                return x * (1 + self.weight) + self.bias
+            else:
+                return x * (1 + self.weight)
+        else:
+            return x
+
+
+class RotaryEmbedding(nn.Module):
+    """
+    [Rotary positional embeddings (RoPE)](https://arxiv.org/abs/2104.09864).
+    """
+
+    def __init__(self, config: ModelConfig, cache: BufferCache):
+        super().__init__()
+        self.config = config
+        self.__cache = cache
+        # Warm up cache.
+        self.rope_theta = config.rope_theta
+        self.get_rotary_embedding(config.max_sequence_length, _non_meta_init_device(config))
+
+    def get_rotary_embedding(self, seq_len: int, device: torch.device) -> Tuple[torch.Tensor, torch.Tensor]:
+        if (
+            (pos_sin := self.__cache.get("rope_pos_sin")) is not None
+            and (pos_cos := self.__cache.get("rope_pos_cos")) is not None
+            and pos_sin.shape[-2] >= seq_len
+            and pos_cos.shape[-2] >= seq_len
+        ):
+            if pos_sin.device != device:
+                pos_sin = pos_sin.to(device)
+                self.__cache["rope_pos_sin"] = pos_sin
+            if pos_cos.device != device:
+                pos_cos = pos_cos.to(device)
+                self.__cache["rope_pos_cos"] = pos_cos
+            return pos_sin[:, :, :seq_len, :], pos_cos[:, :, :seq_len, :]
+
+        with torch.autocast(device.type, enabled=False):
+            dim = self.config.d_model // self.config.n_heads
+            inv_freq = 1.0 / (self.rope_theta ** (torch.arange(0, dim, 2, device=device, dtype=torch.float) / dim))
+            seq = torch.arange(seq_len, device=device, dtype=torch.float)
+            freqs = einsum("i , j -> i j", seq, inv_freq)
+            positions = torch.cat((freqs, freqs), dim=-1)
+            pos_sin, pos_cos = positions.sin()[None, None, :, :], positions.cos()[None, None, :, :]
+        self.__cache["rope_pos_sin"] = pos_sin
+        self.__cache["rope_pos_cos"] = pos_cos
+        return pos_sin, pos_cos
+
+    def rotate_half(self, x: torch.Tensor) -> torch.Tensor:
+        B, nh, T, hs = x.size()
+        x = x.view(B, nh, T, 2, hs // 2)
+        x1, x2 = x.unbind(dim=-2)
+        return torch.cat((-x2, x1), dim=-1)
+
+    def apply_rotary_pos_emb(self, pos_sin: torch.Tensor, pos_cos: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
+        return ((t * pos_cos) + (self.rotate_half(t) * pos_sin)).to(t.dtype)
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        position_ids: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if self.config.rope_full_precision:
+            q_, k_ = q.float(), k.float()
+        else:
+            q_, k_ = q, k
+
+        with torch.autocast(q.device.type, enabled=False):
+            query_len, key_len = q_.shape[-2], k_.shape[-2]  # could be different if layer_past not None
+            if position_ids is not None:
+                # Per-token positions (batch_size, seq_len). Requires query_len ==
+                # key_len (no KV cache, which the MDM forward already enforces) and
+                # position values < max(key_len, max_sequence_length).
+                assert query_len == key_len, "position_ids require query_len == key_len (no KV cache)"
+                table_len = max(key_len, self.config.max_sequence_length)
+                pos_sin, pos_cos = self.get_rotary_embedding(table_len, q_.device)
+                pos_sin = pos_sin.type_as(q_)
+                pos_cos = pos_cos.type_as(q_)
+                # (batch_size, seq_len, dim) gathered tables, broadcast over heads.
+                sin = pos_sin[0, 0][position_ids].unsqueeze(1)
+                cos = pos_cos[0, 0][position_ids].unsqueeze(1)
+                q_ = self.apply_rotary_pos_emb(sin, cos, q_)
+                k_ = self.apply_rotary_pos_emb(sin, cos, k_)
+            else:
+                pos_sin, pos_cos = self.get_rotary_embedding(key_len, q_.device)
+                pos_sin = pos_sin.type_as(q_)
+                pos_cos = pos_cos.type_as(q_)
+                q_ = self.apply_rotary_pos_emb(
+                    pos_sin[:, :, key_len - query_len : key_len, :],
+                    pos_cos[:, :, key_len - query_len : key_len, :],
+                    q_,
+                )
+                k_ = self.apply_rotary_pos_emb(pos_sin, pos_cos, k_)
+        return q_.type_as(q), k_.type_as(k)
+
+
+class Activation(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+
+    @abstractmethod
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def output_multiplier(self) -> float:
+        raise NotImplementedError
+
+    @classmethod
+    def build(cls, config: ModelConfig) -> Activation:
+        if config.activation_type == ActivationType.gelu:
+            return cast(Activation, GELU(approximate="none"))
+        elif config.activation_type == ActivationType.relu:
+            return cast(Activation, ReLU(inplace=False))
+        elif config.activation_type == ActivationType.silu:
+            return cast(Activation, SiLU(inplace=False))
+        elif config.activation_type == ActivationType.swiglu:
+            return SwiGLU(config)
+        else:
+            raise NotImplementedError(f"Unknown activation: '{config.activation_type}'")
+
+
+class GELU(nn.GELU):
+    @property
+    def output_multiplier(self) -> float:
+        return 1.0
+
+
+class ReLU(nn.ReLU):
+    @property
+    def output_multiplier(self) -> float:
+        return 1.0
+
+class SiLU(nn.SiLU):
+    @property
+    def output_multiplier(self) -> float:
+        return 1.0
+
+class SwiGLU(Activation):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x, gate = x.chunk(2, dim=-1)
+        return F.silu(gate) * x
+
+    @property
+    def output_multiplier(self) -> float:
+        return 0.5
+
+
+def causal_attention_bias(seq_len: int, device: torch.device) -> torch.FloatTensor:
+    att_bias = torch.triu(
+        torch.ones(seq_len, seq_len, device=device, dtype=torch.float),
+        diagonal=1,
+    )
+    att_bias.masked_fill_(att_bias == 1, torch.finfo(att_bias.dtype).min)
+    return att_bias.view(1, 1, seq_len, seq_len)  # type: ignore
+
+
+def get_causal_attention_bias(cache: BufferCache, seq_len: int, device: torch.device) -> torch.Tensor:
+    if (causal_bias := cache.get("causal_attention_bias")) is not None and causal_bias.shape[-1] >= seq_len:
+        if causal_bias.device != device:
+            causal_bias = causal_bias.to(device)
+            cache["causal_attention_bias"] = causal_bias
+        return causal_bias
+    with torch.autocast(device.type, enabled=False):
+        causal_bias = causal_attention_bias(seq_len, device)
+    cache["causal_attention_bias"] = causal_bias
+    return causal_bias
+
+
+def alibi_attention_bias(seq_len: int, config: ModelConfig, device: torch.device) -> torch.FloatTensor:
+    alibi_bias = torch.arange(1 - seq_len, 1, dtype=torch.float, device=device).view(1, 1, 1, seq_len)
+
+    # shape: (1, 1, seq_len, seq_len)
+    alibi_bias = alibi_bias - torch.arange(1 - seq_len, 1, dtype=torch.float, device=device).view(1, 1, seq_len, 1)
+    alibi_bias.abs_().mul_(-1)
+
+    # shape: (n_heads,)
+    m = torch.arange(1, config.n_heads + 1, dtype=torch.float, device=device)
+    m.mul_(config.alibi_bias_max / config.n_heads)
+
+    # shape: (1, n_heads, seq_len, seq_len)
+    return alibi_bias * (1.0 / (2 ** m.view(1, config.n_heads, 1, 1)))  # type: ignore
+
+
+class LLaDABlock(nn.Module):
+    """
+    A base class for transformer block implementations.
+    """
+
+    def __init__(self, layer_id: int, config: ModelConfig, cache: BufferCache):
+        super().__init__()
+        self.layer_id = layer_id
+        self.config = config
+        self.hidden_size = (
+            config.mlp_hidden_size if config.mlp_hidden_size is not None else config.mlp_ratio * config.d_model
+        )
+        self.__cache = cache
+        assert config.d_model % config.n_heads == 0
+
+        self._activation_checkpoint_fn = None
+
+        # Dropout.
+        self.dropout = Dropout(config.residual_dropout)
+
+        # Layer norms.
+        self.k_norm: Optional[LayerNormBase] = None
+        self.q_norm: Optional[LayerNormBase] = None
+        if config.attention_layer_norm:
+            self.k_norm = LayerNormBase.build(
+                config,
+                size=(config.d_model // config.n_heads) * config.effective_n_kv_heads,
+                elementwise_affine=config.attention_layer_norm_with_affine,
+            )
+            self.q_norm = LayerNormBase.build(config, elementwise_affine=config.attention_layer_norm_with_affine)
+
+        # Activation function.
+        self.act = Activation.build(config)
+        assert (self.act.output_multiplier * self.hidden_size) % 1 == 0
+
+        # Attention output projection.
+        self.attn_out = nn.Linear(
+            config.d_model, config.d_model, bias=config.include_bias, device=config.init_device
+        )
+
+        # Feed-forward output projection.
+        self.ff_out = nn.Linear(
+            int(self.act.output_multiplier * self.hidden_size),
+            config.d_model,
+            bias=config.include_bias,
+            device=config.init_device,
+        )
+        self.ff_out._is_residual = True  # type: ignore
+
+        # Rotary embeddings.
+        if self.config.rope:
+            self.rotary_emb = RotaryEmbedding(config, self.__cache)
+
+        self.flash_attn_func = None
+        if config.flash_attention:
+            try:
+                from flash_attn import flash_attn_func  # type: ignore
+
+                self.flash_attn_func = flash_attn_func
+            except ModuleNotFoundError:
+                pass
+
+    def reset_parameters(self):
+        if self.k_norm is not None:
+            self.k_norm.reset_parameters()
+        if self.q_norm is not None:
+            self.q_norm.reset_parameters()
+        init_weights(
+            self.config,
+            self.attn_out,
+            d=self.config.d_model,
+            layer_id=self.layer_id,
+            type_of_module=ModuleType.out_module,
+        )
+        init_weights(
+            self.config,
+            self.ff_out,
+            d=self.ff_out.in_features,
+            layer_id=self.layer_id,
+            type_of_module=ModuleType.out_module,
+        )
+
+    def set_activation_checkpointing(self, strategy: Optional[ActivationCheckpointingStrategy]):
+        if strategy == ActivationCheckpointingStrategy.fine_grained:
+            self._activation_checkpoint_fn = activation_checkpoint_function(self.config)
+        else:
+            self._activation_checkpoint_fn = None
+
+    @classmethod
+    def _cast_attn_bias(cls, bias: torch.Tensor, input_dtype: torch.dtype) -> torch.Tensor:
+        target_dtype = input_dtype
+        # NOTE: `is_autocast_enabled()` only checks for CUDA autocast, so we use the separate function
+        # `is_autocast_cpu_enabled()` for CPU autocast.
+        # See https://github.com/pytorch/pytorch/issues/110966.
+        if bias.device.type == "cuda" and torch.is_autocast_enabled():
+            target_dtype = torch.get_autocast_gpu_dtype()
+        elif bias.device.type == "cpu" and torch.is_autocast_cpu_enabled():
+            target_dtype = torch.get_autocast_cpu_dtype()
+        if bias.dtype != target_dtype:
+            bias = bias.to(target_dtype)
+            ensure_finite_(bias, check_neg_inf=True, check_pos_inf=False)
+        return bias
+
+    def _scaled_dot_product_attention(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        attn_mask: Optional[torch.Tensor] = None,
+        dropout_p: float = 0.0,
+        is_causal: bool = False,
+    ) -> torch.Tensor:
+        """
+        Computes scaled dot product attention on query, key and value tensors, using an optional
+        attention mask if passed, and applying dropout if a probability greater than 0.0 is specified.
+        """
+        if self.flash_attn_func is not None and attn_mask is None:
+            r = self.flash_attn_func(
+                q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2), dropout_p=dropout_p, causal=False
+            )
+            return r.transpose(1, 2)
+        else:
+            # torch's sdpa doesn't support GQA, so we're doing this
+            assert k.size(1) == v.size(1)
+            num_kv_heads = k.size(1)
+            num_q_heads = q.size(1)
+            if num_q_heads != num_kv_heads:
+                assert num_q_heads % num_kv_heads == 0
+                k = k.repeat_interleave(num_q_heads // num_kv_heads, dim=1, output_size=num_q_heads)
+                v = v.repeat_interleave(num_q_heads // num_kv_heads, dim=1, output_size=num_q_heads)
+
+            # Modify: MDM set causal to False.
+            return F.scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                attn_mask=attn_mask,
+                dropout_p=dropout_p,
+                is_causal=False,
+            )
+
+    def attention(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        attention_bias: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.Tensor] = None,
+        layer_past: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        use_cache: bool = False,
+    ) -> Tuple[torch.Tensor, Optional[Tuple[torch.Tensor, torch.Tensor]]]:
+        B, T, C = q.size()  # batch size, sequence length, d_model
+        dtype = k.dtype
+
+        # Optionally apply layer norm to keys and queries.
+        if self.q_norm is not None and self.k_norm is not None:
+            q = self.q_norm(q).to(dtype=dtype)
+            k = self.k_norm(k).to(dtype=dtype)
+
+        # Move head forward to be next to the batch dim.
+        # shape: (B, nh, T, hs)
+        q = q.view(B, T, self.config.n_heads, C // self.config.n_heads).transpose(1, 2)
+        # shape: (B, n_kv_h, T, hs)
+        k = k.view(B, T, self.config.effective_n_kv_heads, C // self.config.n_heads).transpose(1, 2)
+        # shape: (B, n_kv_h, T, hs)
+        v = v.view(B, T, self.config.effective_n_kv_heads, C // self.config.n_heads).transpose(1, 2)
+
+        if layer_past is not None:
+            past_key, past_value = layer_past
+            k = torch.cat((past_key, k), dim=-2)
+            v = torch.cat((past_value, v), dim=-2)
+
+        present = (k, v) if use_cache else None
+        query_len, key_len = q.shape[-2], k.shape[-2]  # could be different if layer_past not None
+
+        if self.config.rope:
+            # Apply rotary embeddings.
+            q, k = self.rotary_emb(q, k, position_ids=position_ids)
+
+        if attention_bias is not None:
+            # Resize and cast attention bias.
+            # The current dtype of the attention bias might not match the dtype that the SDP attn function will
+            # run in if AMP is enabled, and this can be a problem if some tokens are masked out due to padding
+            # as down-casting the attention bias to the autocast precision will result in -infs, which will
+            # cause the SDP attn function to produce NaNs.
+            attention_bias = self._cast_attn_bias(
+                attention_bias[:, :, key_len - query_len : key_len, :key_len], dtype
+            )
+
+        # Get the attention scores.
+        # shape: (B, nh, T, hs)
+        att = self._scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask=attention_bias,
+            dropout_p=0.0 if not self.training else self.config.attention_dropout,
+            is_causal=False,
+        )
+
+        # Re-assemble all head outputs side-by-side.
+        att = att.transpose(1, 2).contiguous().view(B, T, C)
+
+        # Apply output projection.
+        return self.attn_out(att), present
+
+    @abstractmethod
+    def forward(
+        self,
+        x: torch.Tensor,
+        attention_bias: Optional[torch.FloatTensor] = None,
+        position_ids: Optional[torch.Tensor] = None,
+        layer_past: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        use_cache: bool = False,
+    ) -> Tuple[torch.Tensor, Optional[Tuple[torch.Tensor, torch.Tensor]]]:
+        raise NotImplementedError
+
+    @classmethod
+    def build(cls, layer_id: int, config: ModelConfig, cache: BufferCache) -> LLaDABlock:
+        if config.block_type == BlockType.sequential:
+            return LLaDASequentialBlock(layer_id, config, cache)
+        elif config.block_type == BlockType.llama:
+            return LLaDALlamaBlock(layer_id, config, cache)
+        else:
+            raise NotImplementedError(f"Unknown block type: '{config.block_type}'")
+
+
+class LLaDASequentialBlock(LLaDABlock):
+    """
+    This is a typical transformer block where the output is computed as ``MLP(LN(x + Attention(LN(x))))``
+    (plus another skip connection).
+    """
+
+    def __init__(self, layer_id: int, config: ModelConfig, cache: BufferCache):
+        super().__init__(layer_id, config, cache)
+        # Layer norms.
+        self.attn_norm = LayerNorm.build(config)
+        self.ff_norm = LayerNorm.build(config)
+        # Attention input projection. Projects x -> (q, k, v)
+        head_dim = config.d_model // config.n_heads
+        self.fused_dims = (
+            config.d_model,
+            config.effective_n_kv_heads * head_dim,
+            config.effective_n_kv_heads * head_dim,
+        )
+        self.att_proj = nn.Linear(
+            config.d_model, sum(self.fused_dims), bias=config.include_bias | config.include_qkv_bias, device=config.init_device
+        )
+        # Feed-forward input projection.
+        self.ff_proj = nn.Linear(
+            config.d_model, self.hidden_size, bias=config.include_bias, device=config.init_device
+        )
+
+    def reset_parameters(self):
+        super().reset_parameters()
+        self.attn_norm.reset_parameters()
+        self.ff_norm.reset_parameters()
+        # NOTE: the standard deviation for these weights does not depend on the layer.
+        init_weights(
+            self.config, self.att_proj, d=self.config.d_model, layer_id=None, type_of_module=ModuleType.in_module
+        )
+        init_weights(
+            self.config, self.ff_proj, d=self.config.d_model, layer_id=None, type_of_module=ModuleType.in_module
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        attention_bias: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.Tensor] = None,
+        layer_past: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        use_cache: bool = False,
+    ) -> Tuple[torch.Tensor, Optional[Tuple[torch.Tensor, torch.Tensor]]]:
+        # Get query, key, value projections.
+        # shape:
+        #  - for regular attn q, k, v: (batch_size, seq_len, d_model)
+        #  - for multi-query attn q: (batch_size, seq_len, d_model)
+        #                      k, v: (batch_size, seq_len, d_model // n_heads)
+        #  - for group query attn q: (batch_size, seq_len, d_model)
+        #                      k, v: (batch_size, seq_len, d_model // n_kv_heads)
+        if self._activation_checkpoint_fn is not None:
+            q, k, v = self.att_proj(self._activation_checkpoint_fn(self.attn_norm, x)).split(
+                self.fused_dims, dim=-1
+            )
+        else:
+            q, k, v = self.att_proj(self.attn_norm(x)).split(self.fused_dims, dim=-1)
+
+        # Get attention scores.
+        if self._activation_checkpoint_fn is not None:
+            att, cache = self._activation_checkpoint_fn(  # type: ignore
+                self.attention,
+                q,
+                k,
+                v,
+                attention_bias,
+                position_ids=position_ids,
+                layer_past=layer_past,
+                use_cache=use_cache,
+            )
+        else:
+            att, cache = self.attention(
+                q, k, v, attention_bias, position_ids=position_ids, layer_past=layer_past, use_cache=use_cache
+            )
+
+        # Add attention scores.
+        # shape: (B, T, C)
+        x = x + self.dropout(att)
+
+        # Add feed-forward projection.
+        # shape: (batch_size, seq_len, d_model)
+        og_x = x
+        if self._activation_checkpoint_fn is not None:
+            x = self._activation_checkpoint_fn(self.ff_norm, x)  # type: ignore
+        else:
+            x = self.ff_norm(x)
+        x = self.ff_proj(x)
+        if self._activation_checkpoint_fn is not None:
+            x = self._activation_checkpoint_fn(self.act, x)  # type: ignore
+        else:
+            x = self.act(x)
+        x = self.ff_out(x)
+        x = self.dropout(x)
+        x = og_x + x
+
+        return x, cache
+
+
+class LLaDALlamaBlock(LLaDABlock):
+    """
+    This is a transformer block where the output is computed as ``MLP(LN(x + Attention(LN(x))))``
+    (plus another skip connection). This block is similar to `LLaDASequentialBlock`
+    but some operations have slightly different implementations to imitate the
+    behavior of Llama.
+    """
+
+    def __init__(self, layer_id: int, config: ModelConfig, cache: BufferCache):
+        super().__init__(layer_id, config, cache)
+        # Layer norms.
+        self.attn_norm = LayerNorm.build(config)
+        self.ff_norm = LayerNorm.build(config)
+        self.__cache = cache
+
+        # Attention input projection. Projects x -> (q, k, v)
+        head_dim = config.d_model // config.n_heads
+        q_proj_out_dim = config.d_model
+        k_proj_out_dim = config.effective_n_kv_heads * head_dim
+        v_proj_out_dim = config.effective_n_kv_heads * head_dim
+        self.q_proj = nn.Linear(
+            config.d_model, q_proj_out_dim, bias=config.include_bias | config.include_qkv_bias, device=config.init_device
+        )
+        self.k_proj = nn.Linear(
+            config.d_model, k_proj_out_dim, bias=config.include_bias | config.include_qkv_bias, device=config.init_device
+        )
+        self.v_proj = nn.Linear(
+            config.d_model, v_proj_out_dim, bias=config.include_bias | config.include_qkv_bias, device=config.init_device
+        )
+
+        # Feed-forward input projection.
+        self.ff_proj = nn.Linear(
+            config.d_model, self.hidden_size, bias=config.include_bias, device=config.init_device
+        )
+        # new add
+        self.up_proj = nn.Linear(
+            config.d_model, self.hidden_size, bias=config.include_bias, device=config.init_device
+        )
+
+    def reset_parameters(self):
+        super().reset_parameters()
+        self.attn_norm.reset_parameters()
+        self.ff_norm.reset_parameters()
+        # NOTE: the standard deviation for these weights does not depend on the layer.
+        init_weights(self.config, self.q_proj, d=self.config.d_model, layer_id=None)
+        init_weights(self.config, self.k_proj, d=self.config.d_model, layer_id=None)
+        init_weights(self.config, self.v_proj, d=self.config.d_model, layer_id=None)
+        init_weights(self.config, self.ff_proj, d=self.config.d_model, layer_id=None)
+        init_weights(self.config, self.up_proj, d=self.config.d_model, layer_id=None)  # new add
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        attention_bias: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.Tensor] = None,
+        layer_past: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        use_cache: bool = False,
+    ) -> Tuple[torch.Tensor, Optional[Tuple[torch.Tensor, torch.Tensor]]]:
+        # Get query, key, value projections.
+        # shape:
+        #  - for regular attn q, k, v: (batch_size, seq_len, d_model)
+        #  - for multi-query attn q: (batch_size, seq_len, d_model)
+        #                      k, v: (batch_size, seq_len, d_model // n_heads)
+        #  - for group query attn q: (batch_size, seq_len, d_model)
+        #                      k, v: (batch_size, seq_len, d_model // n_kv_heads)
+        x_normed = self.attn_norm(x)
+        q = self.q_proj(x_normed)
+        k = self.k_proj(x_normed)
+        v = self.v_proj(x_normed)
+
+        # Get attention scores.
+        if self._activation_checkpoint_fn is not None:
+            att, cache = self._activation_checkpoint_fn(  # type: ignore
+                self.attention,
+                q,
+                k,
+                v,
+                attention_bias,
+                position_ids=position_ids,
+                layer_past=layer_past,
+                use_cache=use_cache,
+            )
+        else:
+            att, cache = self.attention(
+                q, k, v, attention_bias, position_ids=position_ids, layer_past=layer_past, use_cache=use_cache
+            )
+
+        # Add attention scores.
+        # shape: (B, T, C)
+        x = x + self.dropout(att)
+
+        # Add feed-forward projection.
+        # shape: (batch_size, seq_len, d_model)
+        og_x = x
+        if self._activation_checkpoint_fn is not None:
+            x = self._activation_checkpoint_fn(self.ff_norm, x)  # type: ignore
+        else:
+            x = self.ff_norm(x)
+        x, x_up = self.ff_proj(x), self.up_proj(x) # new add
+        if self._activation_checkpoint_fn is not None:
+            x = self._activation_checkpoint_fn(self.act, x)  # type: ignore
+        else:
+            x = self.act(x)
+        x = x * x_up # new add
+        x = self.ff_out(x)
+        x = self.dropout(x)
+        x = og_x + x
+
+        return x, cache
+
+
+class LLaDAOutput(NamedTuple):
+    logits: torch.FloatTensor
+    """
+    A tensor of shape `(batch_size, seq_len, vocab_size)` representing the log probabilities
+    for the next token *before* normalization via (log) softmax.
+    """
+
+    attn_key_values: Optional[List[Tuple[torch.Tensor, torch.Tensor]]]
+    """
+    Attention keys and values from each block.
+    """
+
+    hidden_states: Optional[Tuple[torch.Tensor]]
+    """
+    Hidden states from each block.
+    """
+
+
+class LLaDAGenerateOutput(NamedTuple):
+    token_ids: torch.LongTensor
+    """
+    The generated token IDs, a tensor of shape `(batch_size, beam_size, max_steps)`.
+    These do *not* include the original input IDs.
+    """
+
+    scores: torch.FloatTensor
+    """
+    The scores of the generated sequences, a tensor of shape `(batch_size, beam_size)`.
+    """
+
+
+class LLaDABlockGroup(nn.ModuleList):
+    def __init__(self, config: ModelConfig, layer_offset: int, modules: Optional[Iterable[nn.Module]] = None):
+        super().__init__(modules)
+        self.config = config
+        self.layer_offset = layer_offset
+        self.activation_checkpointing_strategy: Optional[ActivationCheckpointingStrategy] = None
+        self._activation_checkpoint_fn = activation_checkpoint_function(self.config)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        attention_bias: Optional[torch.FloatTensor] = None,
+        position_ids: Optional[torch.Tensor] = None,
+        layers_past: Optional[List[Tuple[torch.Tensor, torch.Tensor]]] = None,
+        use_cache: bool = False,
+    ) -> Tuple[torch.Tensor, Optional[List[Tuple[torch.Tensor, torch.Tensor]]]]:
+        attn_key_values: Optional[List[Tuple[torch.Tensor, torch.Tensor]]] = [] if use_cache else None
+        for block_idx, block in enumerate(self):
+            layer_past = None if layers_past is None else layers_past[block_idx]
+            block_idx += self.layer_offset
+            if (
+                (self.activation_checkpointing_strategy == ActivationCheckpointingStrategy.whole_layer)
+                or (
+                    self.activation_checkpointing_strategy == ActivationCheckpointingStrategy.one_in_two
+                    and block_idx % 2 == 0
+                )
+                or (
+                    self.activation_checkpointing_strategy == ActivationCheckpointingStrategy.one_in_three
+                    and block_idx % 3 == 0
+                )
+                or (
+                    self.activation_checkpointing_strategy == ActivationCheckpointingStrategy.one_in_four
+                    and block_idx % 4 == 0
+                )
+            ):
+                # shape: (batch_size, seq_len, d_model)
+                x, cache = self._activation_checkpoint_fn(  # type: ignore
+                    block,
+                    x,
+                    attention_bias=attention_bias,
+                    position_ids=position_ids,
+                    layer_past=layer_past,
+                    use_cache=use_cache,
+                )
+            else:
+                # shape: (batch_size, seq_len, d_model)
+                x, cache = block(
+                    x,
+                    attention_bias=attention_bias,
+                    position_ids=position_ids,
+                    layer_past=layer_past,
+                    use_cache=use_cache,
+                )
+            if attn_key_values is not None:
+                assert cache is not None
+                attn_key_values.append(cache)
+        return x, attn_key_values
+
+    def reset_parameters(self):
+        for block in self:
+            block.reset_parameters()
+
+    def set_activation_checkpointing(self, strategy: Optional[ActivationCheckpointingStrategy]):
+        self.activation_checkpointing_strategy = strategy
+        for block in self:
+            block.set_activation_checkpointing(strategy)
+
+
+class LLaDAModel(nn.Module):
+    def __init__(self, config: ModelConfig, init_params: bool = True):
+        super().__init__()
+        self.config = config
+        self.__cache = BufferCache()
+
+        # Validate config.
+        if self.config.alibi and self.config.flash_attention:
+            raise Exception("ALiBi is currently not supported with FlashAttention")
+
+        if self.config.alibi and self.config.rope:
+            raise Exception("ALiBi and RoPE are mutually exclusive")
+
+        if self.config.embedding_size is not None and self.config.embedding_size != self.config.vocab_size:
+            if self.config.embedding_size < self.config.vocab_size:
+                raise Exception("embedding size should be at least as big as vocab size")
+            elif self.config.embedding_size % 128 != 0:
+                import warnings
+
+                warnings.warn(
+                    "Embedding size is not a multiple of 128! This could hurt throughput performance.", UserWarning
+                )
+
+        self.activation_checkpointing_strategy: Optional[ActivationCheckpointingStrategy] = None
+        self._activation_checkpoint_fn: Callable = activation_checkpoint_function(self.config)
+
+        if not (
+            0 < self.config.block_group_size <= self.config.n_layers
+            and self.config.n_layers % self.config.block_group_size == 0
+        ):
+            raise Exception("n layers must be divisible by block group size")
+
+        torch.backends.cuda.enable_flash_sdp(True)
+        torch.backends.cuda.enable_mem_efficient_sdp(False)  # this is super slow so make sure torch won't use it
+
+        self.transformer = nn.ModuleDict(
+            dict(
+                wte=nn.Embedding(
+                    config.embedding_size or config.vocab_size, config.d_model, device=config.init_device
+                ),
+                emb_drop=Dropout(config.embedding_dropout),
+                ln_f=LayerNorm.build(config),
+            )
+        )
+
+        blocks = [LLaDABlock.build(i, config, self.__cache) for i in range(config.n_layers)]
+        if self.config.block_group_size > 1:
+            block_groups = [
+                LLaDABlockGroup(config, i, blocks[i : i + config.block_group_size])
+                for i in range(0, config.n_layers, config.block_group_size)
+            ]
+            self.transformer.update({"block_groups": nn.ModuleList(block_groups)})
+        else:
+            self.transformer.update({"blocks": nn.ModuleList(blocks)})
+
+        if not (self.config.alibi or self.config.rope):
+            self.transformer.update(
+                {"wpe": nn.Embedding(config.max_sequence_length, config.d_model, device=config.init_device)}
+            )
+        if not config.weight_tying:
+            self.transformer.update(
+                {
+                    "ff_out": nn.Linear(
+                        config.d_model,
+                        config.embedding_size or config.vocab_size,
+                        bias=config.include_bias,
+                        device=config.init_device,
+                    )
+                }
+            )
+        # When `init_device="meta"` FSDP will call `reset_parameters()` to initialize weights.
+        if init_params and self.config.init_device != "meta":
+            self.reset_parameters()
+        self.__num_fwd_flops: Optional[int] = None
+
+        # Warm up cache.
+        if self.config.alibi:
+            get_causal_attention_bias(self.__cache, config.max_sequence_length, _non_meta_init_device(config))
+            self.get_alibi_attention_bias(config.max_sequence_length, _non_meta_init_device(config))
+
+    def set_activation_checkpointing(self, strategy: Optional[ActivationCheckpointingStrategy]):
+        self.activation_checkpointing_strategy = strategy
+        if self.config.block_group_size != 1:
+            for block_group in self.transformer.block_groups:
+                block_group.set_activation_checkpointing(strategy)
+        else:
+            for block in self.transformer.blocks:
+                block.set_activation_checkpointing(strategy)
+
+    @property
+    def device(self) -> torch.device:
+        device: torch.device = self.transformer.wte.weight.device  # type: ignore
+        if device.type == "meta":
+            return _non_meta_init_device(self.config)
+        else:
+            return device
+
+    def reset_parameters(self):
+        log.info("Initializing model parameters...")
+        # Top-level embeddings / linear layers.
+        init_weights(
+            self.config,
+            self.transformer.wte,  # type: ignore
+            std_factor=(0.5 * math.sqrt(self.config.d_model)) if self.config.scale_logits else 1.0,
+            type_of_module=ModuleType.emb,
+        )
+        if hasattr(self.transformer, "wpe"):
+            init_weights(self.config, self.transformer.wpe, type_of_module=ModuleType.emb)  # type: ignore
+
+        # Top-level layer norm.
+        self.transformer.ln_f.reset_parameters()  # type: ignore
+
+        # Output weights.
+        if hasattr(self.transformer, "ff_out"):
+            init_weights(self.config, self.transformer.ff_out, type_of_module=ModuleType.final_out)  # type: ignore
+
+        # Let the blocks handle themselves.
+        if self.config.block_group_size == 1:
+            for block in self.transformer.blocks:
+                block.reset_parameters()
+        else:
+            for block_group in self.transformer.block_groups:
+                block_group.reset_parameters()
+
+    def get_alibi_attention_bias(self, seq_len: int, device: torch.device) -> torch.Tensor:
+        if (alibi_bias := self.__cache.get("alibi_attention_bias")) is not None and alibi_bias.shape[
+            -1
+        ] >= seq_len:
+            if alibi_bias.device != device:
+                alibi_bias = alibi_bias.to(device)
+                self.__cache["alibi_attention_bias"] = alibi_bias
+            return alibi_bias
+        with torch.autocast(device.type, enabled=False):
+            alibi_bias = alibi_attention_bias(seq_len, self.config, device)
+        self.__cache["alibi_attention_bias"] = alibi_bias
+        return alibi_bias
+    
+    def get_bidirectional_attention_bias(self, seq_len: int, device: torch.device) -> torch.Tensor:
+        if (bidirectional_bias := self.__cache.get("bidirectional_attention_bias")) is not None and bidirectional_bias.shape[
+            -1
+        ] >= seq_len:
+            if bidirectional_bias.device != device:
+                bidirectional_bias = bidirectional_bias.to(device)
+                self.__cache["bidirectional_attention_bias"] = bidirectional_bias
+            return bidirectional_bias
+        with torch.autocast(device.type, enabled=False):
+            bidirectional_bias = torch.zeros((1, 1, seq_len, seq_len), device=device, dtype=torch.float)
+        self.__cache["bidirectional_attention_bias"] = bidirectional_bias
+        return bidirectional_bias
+    
+    def forward(
+        self,
+        input_ids: torch.LongTensor,
+        input_embeddings: Optional[torch.FloatTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        attention_bias: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.Tensor] = None,
+        past_key_values: Optional[Sequence[Tuple[torch.Tensor, torch.Tensor]]] = None,
+        use_cache: bool = False,
+        last_logits_only: bool = False,
+        output_hidden_states: Optional[bool] = None,
+    ) -> LLaDAOutput:
+        """
+        :param input_ids: A tensor of shape `(batch_size, seq_len)`.
+        :param input_embeddings: A tensor of shape `(batch_size, seq_len, d_model)` with input
+            embeddings. When provided, it is treated as the output of the input embedding layer.
+        :param attention_mask: A tensor of shape `(batch_size, seq_len)` that indicates
+            which input IDs are masked. A `1` value in the mask means that
+            the corresponding input ID should *not* be ignored. A `0` means
+            that the corresponding input ID is masked.
+
+            This has the same meaning as the `attention_mask` in HuggingFace's `transformers`
+            library.
+        :param position_ids: An optional tensor of shape `(batch_size, seq_len)` with per-token
+            RoPE positions. When omitted, positions default to `arange(seq_len)`. Requires
+            `rope=True` and no KV cache.
+        :param attention_bias: A tensor of shape `(batch_size, 1, seq_len, seq_len)`,
+            `(1, 1, seq_len, seq_len)`, or `(seq_len, seq_len)`. This is used
+            to introduce causal or other biases.
+
+            If the tensor is a bool or byte tensor, a `True` or `1` at `attention_bias[:, :, i, j]`
+            indicates that the i-th element in the sequence is allowed to attend to the j-th
+            element in the sequence.
+
+            If the tensor is a float tensor, it will just be added to the attention
+            scores before the softmax.
+
+            The default is causal, which corresponds to a lower-diagonal byte matrix of ones.
+        :param past_key_values: Pre-computed keys and values for each attention block.
+            Can be used to speed up sequential decoding. The `input_ids` which have
+            their past given to this model should not be passed as `input_ids` as they have already been computed.
+        :param use_cache: If `True`, return key and value tensors for each block.
+        :param last_logits_only: If `True`, only compute the logits for the last token of each sequence.
+            This can speed up decoding when you only care about the next token.
+        """
+        # Add Basic MDM Model config check
+        assert not self.config.alibi, "Alibi length extrapolation is not supported for MDM."
+        assert self.config.rope, "Rope must be used in Llama-Encoder for MDM."
+        assert (past_key_values is None and not use_cache), "The kvcache is not suppotred for MDM."
+
+        output_hidden_states = output_hidden_states if output_hidden_states is not None else False
+
+        if past_key_values:
+            assert len(past_key_values) == self.config.n_layers
+
+        batch_size, seq_len = input_ids.size() if input_embeddings is None else input_embeddings.size()[:2]
+        if past_key_values is None:
+            past_length = 0
+        else:
+            past_length = past_key_values[0][0].size(-2)
+
+        # Get embeddings of input.
+        # shape: (batch_size, seq_len, d_model)
+        x = self.transformer.wte(input_ids) if input_embeddings is None else input_embeddings  # type: ignore
+
+        if self.config.input_emb_norm:
+            x = x * (self.config.d_model**0.5)
+
+        if not (self.config.alibi or self.config.rope):
+            # Get positional embeddings.
+            # shape: (1, seq_len)
+            pos = torch.arange(past_length, past_length + seq_len, dtype=torch.long, device=x.device).unsqueeze(0)
+            # shape: (1, seq_len, d_model)
+            pos_emb = self.transformer.wpe(pos)  # type: ignore
+            x = pos_emb + x
+
+        # Add input + positional embeddings and apply dropout.
+        # shape: (batch_size, seq_len, d_model)
+        x = self.transformer.emb_drop(x)  # type: ignore
+
+        # Transform the attention mask into what the blocks expect.
+        if attention_mask is not None and 0.0 in attention_mask:
+            # shape: (batch_size, 1, 1, seq_len)
+            attention_mask = attention_mask.to(dtype=torch.float).view(batch_size, -1)[:, None, None, :]
+            attention_mask = (1.0 - attention_mask) * torch.finfo(attention_mask.dtype).min
+        else:
+            attention_mask = None
+
+        # Merge attention mask with attention bias.
+        if (
+            attention_bias is not None
+            or attention_mask is not None
+            or self.config.alibi
+            # NOTE (epwalsh): we need to initialize the attn bias in order for attn to work properly
+            # with key+value cache. Otherwise `F.scaled_dot_product_attention()` doesn't seem to compute
+            # scores correctly.
+            or past_key_values is not None
+        ):
+            if attention_bias is None and self.config.alibi:
+                attention_bias = get_causal_attention_bias(
+                    self.__cache, past_length + seq_len, x.device
+                ) + self.get_alibi_attention_bias(past_length + seq_len, x.device)
+            elif attention_bias is None:
+                attention_bias = self.get_bidirectional_attention_bias(past_length + seq_len, x.device)
+            elif attention_bias.dtype in (torch.int8, torch.bool):
+                attention_bias = attention_bias.to(dtype=torch.float)
+                attention_bias.masked_fill_(attention_bias == 0.0, torch.finfo(attention_bias.dtype).min)
+
+            # Transform to the right shape and data type.
+            mask_len = seq_len
+            if attention_mask is not None:
+                mask_len = attention_mask.shape[-1]
+            elif past_key_values is not None:
+                mask_len = past_key_values[0][0].shape[-2] + seq_len
+            attention_bias = attention_bias[:, :, :mask_len, :mask_len].to(dtype=torch.float)
+
+            # Add in the masking bias.
+            if attention_mask is not None:
+                attention_bias = attention_bias + attention_mask
+                # Might get -infs after adding attention mask, since dtype.min + dtype.min = -inf.
+                # `F.scaled_dot_product_attention()` doesn't handle -inf like you'd expect, instead
+                # it can produce NaNs.
+                ensure_finite_(attention_bias, check_neg_inf=True, check_pos_inf=False)
+
+        attn_key_values: Optional[List[Tuple[torch.Tensor, torch.Tensor]]] = [] if use_cache else None
+
+        # decoder layers
+        all_hidden_states = []
+
+        # Apply blocks one-by-one.
+        if self.config.block_group_size == 1:
+            for block_idx, block in enumerate(self.transformer.blocks):
+                if output_hidden_states:
+                    # add hidden states
+                    all_hidden_states.append(x)
+
+                layer_past = None if past_key_values is None else past_key_values[block_idx]
+                if (
+                    (self.activation_checkpointing_strategy == ActivationCheckpointingStrategy.whole_layer)
+                    or (
+                        self.activation_checkpointing_strategy == ActivationCheckpointingStrategy.one_in_two
+                        and block_idx % 2 == 0
+                    )
+                    or (
+                        self.activation_checkpointing_strategy == ActivationCheckpointingStrategy.one_in_three
+                        and block_idx % 3 == 0
+                    )
+                    or (
+                        self.activation_checkpointing_strategy == ActivationCheckpointingStrategy.one_in_four
+                        and block_idx % 4 == 0
+                    )
+                ):
+                    # shape: (batch_size, seq_len, d_model)
+                    x, cache = self._activation_checkpoint_fn(
+                        block,
+                        x,
+                        attention_bias=attention_bias,
+                        position_ids=position_ids,
+                        layer_past=layer_past,
+                        use_cache=use_cache,
+                    )
+                else:
+                    # shape: (batch_size, seq_len, d_model)
+                    x, cache = block(
+                        x,
+                        attention_bias=attention_bias,
+                        position_ids=position_ids,
+                        layer_past=layer_past,
+                        use_cache=use_cache,
+                    )
+                if attn_key_values is not None:
+                    assert cache is not None
+                    attn_key_values.append(cache)
+        else:
+            for group_idx, block_group in enumerate(self.transformer.block_groups):
+                if output_hidden_states:
+                    # add hidden states
+                    all_hidden_states.append(x)
+
+                layers_past = (
+                    None
+                    if past_key_values is None
+                    else past_key_values[
+                        group_idx * self.config.block_group_size : (group_idx + 1) * self.config.block_group_size
+                    ]
+                )
+                x, cache = block_group(
+                    x,
+                    attention_bias=attention_bias,
+                    position_ids=position_ids,
+                    layers_past=layers_past,
+                    use_cache=use_cache,
+                )
+                if attn_key_values is not None:
+                    assert cache is not None
+                    attn_key_values.extend(cache)
+
+        if last_logits_only:
+            # shape: (batch_size, 1, d_model)
+            x = x[:, -1, :].unsqueeze(1)
+
+        # Apply final layer norm.
+        # shape: (batch_size, seq_len or 1, d_model)
+        x = self.transformer.ln_f(x)  # type: ignore
+        if output_hidden_states:
+            # add final hidden state post-final-layernorm, following HuggingFace's convention
+            all_hidden_states.append(x)
+
+        # Get logits.
+        # shape: (batch_size, seq_len or 1, vocab_size)
+        if self.config.weight_tying:
+            logits = F.linear(x, self.transformer.wte.weight, None)  # type: ignore
+        else:
+            logits = self.transformer.ff_out(x)  # type: ignore
+        if self.config.scale_logits:
+            logits.mul_(1 / math.sqrt(self.config.d_model))
+
+        return LLaDAOutput(logits=logits, attn_key_values=attn_key_values, hidden_states=tuple(all_hidden_states) if output_hidden_states else None)  # type: ignore[arg-type]
+
+
+def create_model_config_from_pretrained_config(config: LLaDAConfigBase):
+    """
+    Utility function
+    """
+
+    kwargs = {}
+    for field in fields(ModelConfig):
+        kwargs[field.name] = getattr(config, field.name)
+
+    model_config = ModelConfig(**kwargs)
+    return model_config
+
+
+class LLaDAModelLM(PreTrainedModel):
+    """
+    Extremely barebones HF model wrapper.
+    """
+
+    config_class = LLaDAConfigBase
+    base_model_prefix = "model"
+    _no_split_modules = ["LLaDABlock", "LLaDASequentialBlock", "LLaDALlamaBlock"]
+
+    def __init__(self, config: LLaDAConfigBase, model: Optional[LLaDAModel] = None, init_params: bool = False):
+        super().__init__(config)
+
+        if not model:
+            model_config = create_model_config_from_pretrained_config(config)
+            # Initialize model (always on CPU to start with so we don't run out of GPU memory).
+            model_config.init_device = "cpu"
+            self.model = LLaDAModel(model_config, init_params=init_params)
+        else:
+            self.model = model
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        attention_bias: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.Tensor] = None,
+        past_key_values: Optional[List[torch.FloatTensor]] = None,
+        labels: Optional[torch.LongTensor] = None,
+        use_cache: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+        cache_position: Optional[Cache] = None,  # This is a hack mitigation of an issue in transformers `4.39.x`
+    ) -> Union[Tuple, CausalLMOutputWithPast]:
+        if use_cache is None:
+            use_cache = self.config.use_cache
+
+        if output_attentions:
+            raise ValueError("output_attentions is not yet supported in LLaDA")
+
+        # NOTE: upstream used ``self.config.use_return_dict``, deprecated in transformers >= 5.
+        return_dict = return_dict if return_dict is not None else True
+
+        # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
+        outputs = self.model.forward(
+            input_ids=input_ids,
+            input_embeddings=inputs_embeds,
+            attention_mask=attention_mask,
+            attention_bias=attention_bias,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            output_hidden_states=output_hidden_states,
+        )
+
+        logits = outputs.logits
+        hidden_states = outputs.hidden_states
+
+        loss = None
+        if labels is not None:
+            import warnings
+            warnings.warn("Note that for LLaDA, you cannot calculate the loss here.", UserWarning)
+        if not return_dict:
+            output = (logits,) + outputs[1:]
+            return (loss,) + output if loss is not None else output
+
+        return CausalLMOutputWithPast(
+            logits=logits,
+            past_key_values=outputs.attn_key_values,
+            hidden_states=hidden_states,
+        )
+
+    def can_generate(self) -> bool:
+        return True
+
+    def prepare_inputs_for_generation(
+        self, input_ids: torch.LongTensor, past_key_values: Optional[List[Tuple]] = None, **kwargs
+    ):
+        if past_key_values:
+            # This is because we want the model to only process the last generated token.
+            input_ids = input_ids[:, -1:]
+        model_inputs = {"input_ids": input_ids, "past_key_values": past_key_values}
+
+        model_inputs.update(kwargs)
+        model_inputs["use_cache"] = kwargs.pop("use_cache", self.config.use_cache)
+        return model_inputs
+
+    # TODO: these are required to make the implementation complete.
+    # def resize_position_embeddings(self, new_num_position_embeddings: int):
+    #     pass
+    #
+    # def get_position_embeddings(self) -> Union[nn.Embedding, Tuple[nn.Embedding]]:
+    #     pass
+    #
+    # def _reorder_cache(self, past_key_values, beam_idx):
+    #     pass
+
+    def get_input_embeddings(self) -> torch.nn.Module:
+        return self.model.transformer.wte
+
+    def set_input_embeddings(self, value: torch.nn.Module):
+        self.model.transformer.wte = value
+
+    def get_output_embeddings(self):
+        if self.config.weight_tying:
+            return self.model.transformer.wte
+        else:
+            return self.model.transformer.ff_out
+
+    def set_output_embeddings(self, value: torch.nn.Module):
+        if self.config.weight_tying:
+            self.model.transformer.wte = value
+        else:
+            self.model.transformer.ff_out = value
+
+    def tie_weights(self):
+        if self.config.weight_tying:
+            self.model.transformer.ff_out = self.model.transformer.wte

--- a/tests/models/llada/test_llada_model.py
+++ b/tests/models/llada/test_llada_model.py
@@ -1,0 +1,159 @@
+"""CPU tests for the LLaDA backbone + xlm-models adapter.
+
+Run the Hub checkpoint parity test (downloads ~16GB, needs ~35GB RAM or a GPU)
+with::
+
+    XLM_RUN_HUB_TESTS=1 pytest tests/models/llada/test_llada_model.py -k hub
+"""
+
+import os
+
+import pytest
+import torch
+
+
+def tiny_config(**overrides):
+    from llada import LLaDAConfig
+
+    kwargs = dict(
+        d_model=64,
+        n_heads=4,
+        n_layers=2,
+        mlp_hidden_size=128,
+        activation_type="silu",
+        block_type="llama",
+        rope=True,
+        rope_theta=500000.0,
+        layer_norm_type="rms",
+        rms_norm_eps=1e-05,
+        weight_tying=False,
+        include_bias=False,
+        include_qkv_bias=False,
+        attention_dropout=0.0,
+        embedding_dropout=0.0,
+        residual_dropout=0.0,
+        max_sequence_length=64,
+        vocab_size=100,
+        embedding_size=128,
+        mask_token_id=99,
+        pad_token_id=98,
+        eos_token_id=98,
+        use_cache=False,
+        init_device="cpu",
+    )
+    kwargs.update(overrides)
+    return LLaDAConfig(**kwargs)
+
+
+@pytest.fixture()
+def tiny_llada_model():
+    from llada import LLaDAXLMModel
+
+    torch.manual_seed(0)
+    model = LLaDAXLMModel(tiny_config(), init_params=True)
+    model.eval()
+    return model
+
+
+class TestLLaDAConfig:
+    def test_model_config_fields_survive_roundtrip(self):
+        """transformers >= 5 drops some config kwargs; the base __init__ must restore them."""
+        from dataclasses import fields
+
+        from xlm.backbones.llada.configuration_llada import ModelConfig
+
+        cfg = tiny_config()
+        for f in fields(ModelConfig):
+            assert hasattr(cfg, f.name), f"missing ModelConfig field: {f.name}"
+
+    def test_model_config_roundtrip_into_inner_model(self):
+        from xlm.backbones.llada.modeling_llada import (
+            create_model_config_from_pretrained_config,
+        )
+
+        mc = create_model_config_from_pretrained_config(tiny_config())
+        assert mc.d_model == 64
+        assert mc.n_kv_heads is None or isinstance(mc.n_kv_heads, int)
+        assert mc.effective_n_kv_heads == 4
+
+
+class TestLLaDAXLMModel:
+    def test_forward_shape(self, tiny_llada_model):
+        x = torch.randint(0, 100, (2, 16))
+        with torch.no_grad():
+            logits = tiny_llada_model(x)
+        assert logits.shape == (2, 16, 128)  # embedding_size, not vocab_size
+
+    def test_mlm_protocol_signature(self, tiny_llada_model):
+        """(x_t, attention_mask, positions) -> logits, like DreamXLMModel."""
+        x = torch.randint(0, 100, (2, 16))
+        attention_mask = torch.ones(2, 16, dtype=torch.bool)
+        attention_mask[1, -4:] = False
+        positions = (attention_mask.long().cumsum(-1) - 1).clamp(min=0)
+        with torch.no_grad():
+            logits = tiny_llada_model(x, attention_mask, positions)
+        assert logits.shape == (2, 16, 128)
+
+    def test_position_ids_default_parity(self, tiny_llada_model):
+        """positions == arange must be bitwise identical to the default RoPE path."""
+        x = torch.randint(0, 100, (2, 16))
+        positions = torch.arange(16).unsqueeze(0).expand(2, -1)
+        with torch.no_grad():
+            base = tiny_llada_model(x)
+            with_pos = tiny_llada_model(x, None, positions)
+        assert torch.equal(base, with_pos)
+
+    def test_padding_mask_changes_only_padded_context(self, tiny_llada_model):
+        """Masking out trailing pads must not equal the unmasked forward."""
+        x = torch.randint(0, 100, (1, 16))
+        attention_mask = torch.ones(1, 16, dtype=torch.bool)
+        attention_mask[:, -4:] = False
+        with torch.no_grad():
+            unmasked = tiny_llada_model(x)
+            masked = tiny_llada_model(x, attention_mask)
+        assert not torch.allclose(unmasked[:, :12], masked[:, :12])
+
+    def test_state_dict_keys_match_hf_layout(self, tiny_llada_model):
+        keys = set(tiny_llada_model.state_dict().keys())
+        assert "model.transformer.wte.weight" in keys
+        assert "model.transformer.ln_f.weight" in keys
+        assert "model.transformer.ff_out.weight" in keys  # untied head
+        assert "model.transformer.blocks.0.q_proj.weight" in keys
+        assert "model.transformer.blocks.1.up_proj.weight" in keys
+
+    def test_strict_state_dict_roundtrip(self, tiny_llada_model):
+        from llada import LLaDAXLMModel
+
+        fresh = LLaDAXLMModel(tiny_config(), init_params=False)
+        fresh.load_state_dict(tiny_llada_model.state_dict(), strict=True)
+        x = torch.randint(0, 100, (2, 8))
+        with torch.no_grad():
+            assert torch.equal(tiny_llada_model(x), fresh(x))
+
+
+@pytest.mark.skipif(
+    os.environ.get("XLM_RUN_HUB_TESTS", "0") != "1",
+    reason="set XLM_RUN_HUB_TESTS=1 to download GSAI-ML/LLaDA-8B-Base and run parity",
+)
+class TestLLaDAHubParity:
+    def test_checkpoint_logits_parity(self):
+        """Our port must reproduce the trust_remote_code reference on real weights."""
+        from transformers import AutoModel
+
+        from llada import LLaDAXLMModel
+
+        repo = "GSAI-ML/LLaDA-8B-Base"
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        ours = LLaDAXLMModel.from_pretrained(repo, dtype=torch.bfloat16).to(device).eval()
+        ref = (
+            AutoModel.from_pretrained(repo, trust_remote_code=True, dtype=torch.bfloat16)
+            .to(device)
+            .eval()
+        )
+        torch.manual_seed(0)
+        x = torch.randint(0, 126080, (2, 32), device=device)
+        x[:, -8:] = 126336  # mask tokens
+        with torch.no_grad():
+            ref_logits = ref(input_ids=x).logits.float()
+            our_logits = ours(x).float()
+        assert torch.allclose(ref_logits, our_logits, atol=1e-3, rtol=1e-3)

--- a/xlm-models/dream/predictor_dream.py
+++ b/xlm-models/dream/predictor_dream.py
@@ -245,6 +245,16 @@ def check_batched_generate_until(
     return mask
 
 
+def trim_at_stop_strings(text: str, stop_strings: List[str]) -> str:
+    """Cut text at the first occurrence of any stop string (stop string excluded)."""
+    cut = len(text)
+    for s in stop_strings:
+        idx = text.find(s)
+        if idx != -1:
+            cut = min(cut, idx)
+    return text[:cut]
+
+
 class DreamPredictor(torch.nn.Module, Predictor[MLMBatch, MLMPredictionDict]):
     """Same as MLMPredictor for now."""
 
@@ -644,7 +654,19 @@ class DreamPredictor(torch.nn.Module, Predictor[MLMBatch, MLMPredictionDict]):
         final_time = time.time() - _start_time
         time_taken[time_taken == 0] = final_time
 
-        (out, final_x) = self.decode(step_results)
+        final_x = step_results["x"]
+        # Decode only the generated span; the full canvas includes the
+        # (left-padded) prompt, which must not leak into logged predictions
+        # or downstream evaluators like Math500Eval.
+        out: List[str] = tokenizer.batch_decode(
+            final_x[:, output_start_idx:],
+            skip_special_tokens=self.skip_special_tokens,
+        )
+        if self._generate_until_strings:
+            out = [
+                trim_at_stop_strings(t, list(self._generate_until_strings))
+                for t in out
+            ]
 
         self.reset()
         if flags.DEBUG_PRINT_PREDS:

--- a/xlm-models/llada/__init__.py
+++ b/xlm-models/llada/__init__.py
@@ -1,0 +1,12 @@
+from .configuration_llada import LLaDAConfig
+from .datamodule_llada import print_batch_llada
+from .llada_model import LLaDAHFModel, LLaDAXLMModel
+from .predictor_llada import LLaDAPredictor
+
+__all__ = [
+    "LLaDAXLMModel",
+    "LLaDAConfig",
+    "LLaDAHFModel",
+    "LLaDAPredictor",
+    "print_batch_llada",
+]

--- a/xlm-models/llada/configs/collator/math500_pred_llada.yaml
+++ b/xlm-models/llada/configs/collator/math500_pred_llada.yaml
@@ -1,0 +1,12 @@
+_target_: mlm.datamodule_mlm.MLMSeq2SeqPredCollator
+tokenizer: ${global_components:tokenizer}
+noise_schedule: ${global_components:noise_schedule}
+block_size: ${block_size}
+input_block_size: ${block_size}
+add_bos: false
+add_eos: false
+truncate: block
+prompt_field: prompt_ids
+pass_through_fields:
+  - answer
+  - target

--- a/xlm-models/llada/configs/datamodule/math500_llada.yaml
+++ b/xlm-models/llada/configs/datamodule/math500_llada.yaml
@@ -1,0 +1,13 @@
+# @package _global_
+defaults:
+  - default
+  - /collator@datamodule.dataset_managers.val.math500_prediction.collator: math500_pred_llada
+  - /collator@datamodule.dataset_managers.test.math500_prediction.collator: math500_pred_llada
+  - /datasets@datamodule.dataset_managers.val.math500_prediction: math500_test
+  - /datasets@datamodule.dataset_managers.test.math500_prediction: math500_test
+
+datamodule:
+  print_batch_fn: llada.datamodule_llada.print_batch_llada
+
+tags:
+  dataset: math500

--- a/xlm-models/llada/configs/debug/math500_debug.yaml
+++ b/xlm-models/llada/configs/debug/math500_debug.yaml
@@ -1,0 +1,34 @@
+# @package _global_
+defaults:
+  - override /callbacks: debug_v2
+  - override /loggers: debug
+
+paths:
+  log_dir: ${paths.root_dir}/debug_logs/
+
+num_dataset_workers: 1 # does not accept 0
+global_batch_size: 1
+num_dataloader_workers: 0
+per_device_batch_size: 1
+dataloader_prefetch_factor: null
+dataloader_persistent_workers: False
+
+
+trainer:
+  log_every_n_steps: 1
+  limit_train_batches: 5
+  limit_val_batches: 5
+  limit_test_batches: 5
+
+datamodule:
+  dataset_managers:
+    val:
+      math500_prediction:
+        preprocess_function_kwargs:
+          num_fewshot: 1
+        load_from_cache_file: false
+    test:
+      math500_prediction:
+        preprocess_function_kwargs:
+          num_fewshot: 1
+        load_from_cache_file: false

--- a/xlm-models/llada/configs/experiment/math500_llada_eval.yaml
+++ b/xlm-models/llada/configs/experiment/math500_llada_eval.yaml
@@ -1,0 +1,52 @@
+# @package _global_
+defaults:
+  - override /callbacks: default_hf
+  - override /datamodule: math500_llada
+  - override /noise_schedule: dummy
+  - override /model_type: llada_eval
+  - override /model: llada_8b
+
+per_device_batch_size: 4
+global_batch_size: 4
+block_size: 512
+monitored_metric: null
+init_dtype: bfloat16
+skip_init_weights: true
+
+global_components:
+  tokenizer:
+    _target_: xlm.datamodule.load_auto_tokenizer
+    pretrained_model_name_or_path: GSAI-ML/LLaDA-8B-Base
+    special_tokens:
+      mask_token: "<|mdm_mask|>"  # id 126336, already in the checkpoint vocab
+
+hub:
+  repo_id: GSAI-ML/LLaDA-8B-Base
+
+eval:
+  split: test
+
+predictor:
+  max_new_tokens: ${block_size}
+  max_steps: 512
+  temperature: 0.0
+  confidence: top_prob  # == LLaDA reference remasking='low_confidence'
+  block_size: 32  # == LLaDA reference block_length (semi-AR)
+  generate_until:
+    - <|endoftext|>
+    - "Problem:"
+    - <|eot_id|>
+
+log_predictions:
+  _target_: xlm.log_predictions.LogPredictions
+  writers:
+    - file
+  additional_fields_from_batch:
+    - answer
+
+post_hoc_evaluator:
+  _target_: xlm.tasks.math500.Math500Eval
+
+trainer:
+  max_steps: 0
+  num_sanity_val_steps: 0

--- a/xlm-models/llada/configs/experiment/math500_llada_eval.yaml
+++ b/xlm-models/llada/configs/experiment/math500_llada_eval.yaml
@@ -8,7 +8,12 @@ defaults:
 
 per_device_batch_size: 4
 global_batch_size: 4
-block_size: 512
+# block_size == generation budget (predictor.max_new_tokens). LLaDA reference
+# MATH eval uses gen_length=256 with steps=256 (1 token/step).
+block_size: 256
+# Separate prompt budget: 4-shot MATH-500 prompts are 1364-2638 tokens with the
+# LLaDA tokenizer, so 2688 avoids left-truncation (2688 + 256 <= 4096 context).
+prompt_block_size: 2688
 monitored_metric: null
 init_dtype: bfloat16
 skip_init_weights: true
@@ -26,9 +31,27 @@ hub:
 eval:
   split: test
 
+datamodule:
+  dataset_managers:
+    val:
+      math500_prediction:
+        collator:
+          input_block_size: ${prompt_block_size}
+    test:
+      math500_prediction:
+        collator:
+          input_block_size: ${prompt_block_size}
+
+# These two callbacks in the shared `default_hf` group point at classes that no
+# longer exist (xlm.datamodule.base.PrintBatchCallback,
+# xlm.diffusion.base.UnconditionalSampleGenerator); disable them here.
+callbacks:
+  print_batch: null
+  unconditional_sample_generator: null
+
 predictor:
   max_new_tokens: ${block_size}
-  max_steps: 512
+  max_steps: 256
   temperature: 0.0
   confidence: top_prob  # == LLaDA reference remasking='low_confidence'
   block_size: 32  # == LLaDA reference block_length (semi-AR)
@@ -44,8 +67,14 @@ log_predictions:
   additional_fields_from_batch:
     - answer
 
+# The default post_hoc_evaluator group is CompositePostHocEvaluator with
+# `evaluators: {}`; overriding only _target_ leaves that key behind and breaks
+# instantiation (Math500Eval takes no arguments). Nest it instead.
 post_hoc_evaluator:
-  _target_: xlm.tasks.math500.Math500Eval
+  _target_: xlm.tasks.composite_eval.CompositePostHocEvaluator
+  evaluators:
+    math500_prediction:
+      _target_: xlm.tasks.math500.Math500Eval
 
 trainer:
   max_steps: 0

--- a/xlm-models/llada/configs/experiment/math500_llada_eval.yaml
+++ b/xlm-models/llada/configs/experiment/math500_llada_eval.yaml
@@ -60,6 +60,10 @@ predictor:
   max_steps: 256
   temperature: 0.0
   confidence: top_prob  # == LLaDA reference remasking='low_confidence'
+  # Must be 0 for greedy (argmax-of-confidence) position selection, matching the
+  # reference. The default 1.0 samples positions with Gumbel noise of scale ~1
+  # added to top_prob scores in [0,1], i.e. near-uniform random order.
+  confidence_temperature: 0.0
   # Reference *base-model* eval (EVAL.md) uses block_length == gen_length
   # (single global block, no semi-AR). block_length=32 is the Instruct demo
   # setting and starves long solutions of budget.

--- a/xlm-models/llada/configs/experiment/math500_llada_eval.yaml
+++ b/xlm-models/llada/configs/experiment/math500_llada_eval.yaml
@@ -6,8 +6,8 @@ defaults:
   - override /model_type: llada_eval
   - override /model: llada_8b
 
-per_device_batch_size: 4
-global_batch_size: 4
+per_device_batch_size: 8
+global_batch_size: 8
 # block_size == generation budget (predictor.max_new_tokens). LLaDA reference
 # MATH eval uses gen_length=256 with steps=256 (1 token/step).
 block_size: 256
@@ -31,16 +31,22 @@ hub:
 eval:
   split: test
 
+# truncate: null pads prompts to the batch max instead of a fixed
+# prompt_block_size (attention is O(L^2); fixed 2688 padding dominated the
+# v2 runtime). All 4-shot prompts (max 2638 tokens) fit the 4096 context
+# alongside the 256-token generation, so no truncation is needed.
 datamodule:
   dataset_managers:
     val:
       math500_prediction:
         collator:
           input_block_size: ${prompt_block_size}
+          truncate: null
     test:
       math500_prediction:
         collator:
           input_block_size: ${prompt_block_size}
+          truncate: null
 
 # These two callbacks in the shared `default_hf` group point at classes that no
 # longer exist (xlm.datamodule.base.PrintBatchCallback,
@@ -54,7 +60,10 @@ predictor:
   max_steps: 256
   temperature: 0.0
   confidence: top_prob  # == LLaDA reference remasking='low_confidence'
-  block_size: 32  # == LLaDA reference block_length (semi-AR)
+  # Reference *base-model* eval (EVAL.md) uses block_length == gen_length
+  # (single global block, no semi-AR). block_length=32 is the Instruct demo
+  # setting and starves long solutions of budget.
+  block_size: ${block_size}
   generate_until:
     - <|endoftext|>
     - "Problem:"

--- a/xlm-models/llada/configs/fsdp/decoder_lm_example.yaml
+++ b/xlm-models/llada/configs/fsdp/decoder_lm_example.yaml
@@ -1,0 +1,14 @@
+# Example FSDP grouping for the LLaDA decoder (embed + per-layer + output head).
+# Paths follow the LLaDA checkpoint layout (model.transformer.*, ff_out untied head).
+# Use with ``build_fsdp_grouping_plan_from_config`` and ``context: { model: ${model} }``.
+fsdp_grouping:
+  embed:
+    path: model.transformer.wte
+    wrap: false
+  layers:
+    path_template: "model.transformer.blocks.{i}"
+    wrap: false
+    count: ${model.config.n_layers}
+  head:
+    path: model.transformer.ff_out
+    wrap: true

--- a/xlm-models/llada/configs/model/llada_8b.yaml
+++ b/xlm-models/llada/configs/model/llada_8b.yaml
@@ -1,0 +1,47 @@
+_target_: llada.llada_model.LLaDAXLMModel
+init_params: false
+config:
+  _target_: llada.configuration_llada.LLaDAConfig
+  # Aligned with https://huggingface.co/GSAI-ML/LLaDA-8B-Base/blob/main/config.json
+  # (LLaDA-8B-Instruct shares the same architecture; select weights via hub.repo_id.)
+  d_model: 4096
+  n_heads: 32
+  n_kv_heads: 32
+  n_layers: 32
+  mlp_hidden_size: 12288
+  mlp_ratio: 4
+  activation_type: silu
+  block_type: llama
+  block_group_size: 1
+  alibi: false
+  alibi_bias_max: 8.0
+  rope: true
+  rope_theta: 500000.0
+  rope_full_precision: true
+  flash_attention: false
+  attention_dropout: 0.0
+  multi_query_attention: null
+  attention_layer_norm: false
+  attention_layer_norm_with_affine: true
+  residual_dropout: 0.0
+  embedding_dropout: 0.0
+  input_emb_norm: false
+  layer_norm_type: rms
+  layer_norm_with_affine: true
+  rms_norm_eps: 1e-05
+  bias_for_layer_norm: false
+  max_sequence_length: 4096
+  include_qkv_bias: false
+  include_bias: false
+  scale_logits: false
+  vocab_size: 126464
+  embedding_size: 126464
+  weight_tying: false
+  eos_token_id: 126081
+  pad_token_id: 126081
+  mask_token_id: 126336
+  init_fn: mitchell
+  init_std: 0.02
+  init_cutoff_factor: null
+  init_device: cpu
+  use_cache: false

--- a/xlm-models/llada/configs/model_type/llada_base.yaml
+++ b/xlm-models/llada/configs/model_type/llada_base.yaml
@@ -1,0 +1,11 @@
+# @package _global_
+# Shared LLaDA harness + predictor. Compose via `llada_eval` (eval-only).
+# NOTE: no logits_hook — LLaDA predicts masked positions in place (no Dream-style shift).
+lightning_module:
+  _target_: xlm.harness.Harness
+
+predictor:
+  _target_: llada.predictor_llada.LLaDAPredictor
+
+tags:
+  model_type: llada

--- a/xlm-models/llada/configs/model_type/llada_eval.yaml
+++ b/xlm-models/llada/configs/model_type/llada_eval.yaml
@@ -1,0 +1,4 @@
+# @package _global_
+# Eval / inference: same as llada_base (no accumulated_loss metrics; avoids mandatory prefix/update_fn).
+defaults:
+  - llada_base

--- a/xlm-models/llada/configuration_llada.py
+++ b/xlm-models/llada/configuration_llada.py
@@ -1,0 +1,19 @@
+"""LLaDA variant config (reference: GSAI-ML/LLaDA-8B-{Base,Instruct} Hub)."""
+
+from xlm.backbones.llada.configuration_llada import LLaDAConfigBase
+
+
+class LLaDAConfig(LLaDAConfigBase):
+    """Configuration for LLaDA checkpoints.
+
+    Base and Instruct share the same architecture; the experiment's
+    ``hub.repo_id`` selects which initial weights are loaded.
+
+    NOTE: the explicit ``__init__`` is required with transformers >= 5, which
+    otherwise replaces the inherited ``__init__`` of config subclasses with a
+    generated dataclass one, silently skipping ``LLaDAConfigBase``'s
+    ModelConfig-default handling.
+    """
+
+    def __init__(self, use_cache: bool = False, **kwargs):
+        super().__init__(use_cache=use_cache, **kwargs)

--- a/xlm-models/llada/datamodule_llada.py
+++ b/xlm-models/llada/datamodule_llada.py
@@ -1,0 +1,25 @@
+"""LLaDA-specific data utilities for xlm-core (batch printing, etc.)."""
+
+from typing import Any, Dict
+
+from xlm.datamodule import Tokenizer
+from xlm.utils.rank_zero import RankedLogger
+
+logger = RankedLogger(__name__, rank_zero_only=True)
+
+
+def print_batch_llada(
+    batch: Dict[str, Any],
+    split: str,
+    tokenizer: Tokenizer,
+    dataloader_name: str = "",
+) -> None:
+    """Debug helper that logs the first example of a LLaDA / MLM prediction batch."""
+    ids = batch["input_ids"][0]
+    mask = batch["attention_mask"][0]
+    text = tokenizer.decode(ids[mask.bool()], skip_special_tokens=False)
+    logger.info(
+        f"[LLaDA] split={split}  dl_name={dataloader_name}  "
+        f"shape={tuple(batch['input_ids'].shape)}  "
+        f"prompt_preview={text}"
+    )

--- a/xlm-models/llada/llada_model.py
+++ b/xlm-models/llada/llada_model.py
@@ -1,0 +1,40 @@
+"""LLaDA model: LLaDAModelLM with LLaDA-specific config and MLM-protocol adapter."""
+
+from typing import Optional
+
+from torch import Tensor
+
+from xlm.backbones.llada.modeling_llada import LLaDAModelLM
+
+from .configuration_llada import LLaDAConfig
+
+
+class LLaDAHFModel(LLaDAModelLM):
+    """LLaDA decoder — a pure forward-pass HF model (input_ids -> CausalLMOutputWithPast)."""
+
+    config_class = LLaDAConfig
+
+
+class LLaDAXLMModel(LLaDAHFModel):
+    """Same weights as ``LLaDAHFModel``; ``forward`` matches the MLM predictor protocol.
+
+    Accepts a 2D ``attention_mask`` (handled natively by the LLaDA backbone,
+    unlike Dream which needs a 4D expansion), forwards packed ``positions`` as
+    RoPE ``position_ids``, and returns logits only (no output dataclass).
+    HF checkpoints load without key prefixing. Unlike Dream there is no
+    next-token shift: LLaDA predicts each masked position in place, so no
+    ``LogitsShiftBy1`` hook is needed.
+    """
+
+    def forward(
+        self,
+        x_t: Tensor,
+        attention_mask: Optional[Tensor] = None,
+        positions: Optional[Tensor] = None,
+    ) -> Tensor:
+        output = super().forward(
+            input_ids=x_t,
+            attention_mask=attention_mask,
+            position_ids=positions,
+        )
+        return output.logits

--- a/xlm-models/llada/predictor_llada.py
+++ b/xlm-models/llada/predictor_llada.py
@@ -1,0 +1,28 @@
+"""LLaDA diffusion predictor.
+
+LLaDA's reference sampler (``generate.py`` in https://github.com/ML-GSAI/LLaDA)
+fills a fixed canvas of ``mask_token_id`` (126336) and iteratively commits the
+most confident predictions per semi-autoregressive block ("low-confidence
+remasking"). ``DreamPredictor`` already implements exactly this machinery, so
+``LLaDAPredictor`` reuses it; the reference behavior corresponds to:
+
+- ``confidence: top_prob``  == LLaDA's ``remasking='low_confidence'``
+  (``confidence: null`` gives ``remasking='random'``)
+- ``block_size``            == LLaDA's ``block_length`` (semi-AR blocks)
+- ``max_steps``             == LLaDA's ``steps``
+- ``max_new_tokens``        == LLaDA's ``gen_length``
+- ``temperature: 0.0``      == LLaDA's greedy ``temperature=0.``
+
+Unlike Dream, do NOT configure a ``logits_hook`` (Dream needs
+``LogitsShiftBy1`` for its next-token alignment; LLaDA predicts in place).
+Classifier-free guidance (``cfg_scale``) from the reference sampler is not
+implemented.
+"""
+
+from dream.predictor_dream import DreamPredictor
+
+
+class LLaDAPredictor(DreamPredictor):
+    """Masked-diffusion predictor for LLaDA (see module docstring)."""
+
+    pass

--- a/xlm-models/mlm/datamodule_mlm.py
+++ b/xlm-models/mlm/datamodule_mlm.py
@@ -680,6 +680,7 @@ class MLMSeq2SeqPredCollator(MLMSeq2SeqCollator):
             prefix_ids_list,
             self.tokenizer.pad_token_id,
             max_seq_len=self.input_block_size,
+            truncate=self.truncate,
         )
         suffix_lists = self._suffix_lists(examples)
         if all(len(s) == 0 for s in suffix_lists):

--- a/xlm-models/setup.py
+++ b/xlm-models/setup.py
@@ -20,13 +20,14 @@ setup(
     - mdlm: Masked Diffusion Language Model
     - flexmdm: Flexible Masked Diffusion Language Model
     - dream: Dream diffusion LM 
+    - llada: LLaDA masked diffusion LM
     
     Usage:
         pip install xlm-models
 
         Model package names must be specified in the XLM_MODEL_PACKAGES environment variable as a colon-separated list (e.g., arlm:mlm:ilm:mdlm:dream)
     """,
-    packages=["arlm", "mlm", "ilm", "mdlm", "flexmdm", "dream"],
+    packages=["arlm", "mlm", "ilm", "mdlm", "flexmdm", "dream", "llada"],
     author="Dhruvesh Patel, Benjamin Rozonoyer, Sai Sreenivas Chintha, Durga Prasad Maram",
     package_dir={
         "arlm": "arlm",
@@ -35,6 +36,7 @@ setup(
         "mdlm": "mdlm",
         "flexmdm": "flexmdm",
         "dream": "dream",
+        "llada": "llada",
     },
     package_data={
         "arlm": ["configs/**/*.yaml", "configs/**/*.yml"],
@@ -43,6 +45,7 @@ setup(
         "mdlm": ["configs/**/*.yaml", "configs/**/*.yml"],
         "flexmdm": ["configs/**/*.yaml", "configs/**/*.yml"],
         "dream": ["configs/**/*.yaml", "configs/**/*.yml"],
+        "llada": ["configs/**/*.yaml", "configs/**/*.yml"],
     },
     install_requires=[
         f"xlm-core=={VERSION['VERSION']}",

--- a/xlm-models/xlm_models.json
+++ b/xlm-models/xlm_models.json
@@ -4,5 +4,6 @@
     "mlm": "mlm",
     "mdlm": "mdlm",
     "flexmdm": "flexmdm",
-    "dream": "dream"
+    "dream": "dream",
+    "llada": "llada"
 }


### PR DESCRIPTION
## What

Integrate LLaDA (GSAI-ML/LLaDA-8B-Base/Instruct) into xlm-core at Dream parity: a backbone port with strict HF checkpoint loading, an `xlm-models/llada/` package with an MLM-protocol adapter and diffusion predictor, and Hydra configs including a MATH-500 eval experiment.

## Contribution type

<!-- Check all that apply -->

- [x] Maintained model (`xlm-models/`)
- [ ] External model (separate repo)
- [ ] Task or dataset
- [x] Core framework (`src/xlm/`)
- [ ] Documentation
- [ ] Bug fix
- [ ] Breaking change (apply the `breaking-change` label and include migration notes below)
- [ ] Other (describe below)

## Labels

`model`, `enhancement`

## Changes

- **Backbone `src/xlm/backbones/llada/`**: `modeling_llada.py` / `configuration_llada.py` ported from the GSAI-ML/LLaDA-8B-Base trust_remote_code files, with state-dict keys kept identical to the checkpoint (`model.transformer.wte`, `model.transformer.blocks.*`, `model.transformer.ff_out`) so Hub weights load with `strict=True` and zero remapping — same approach as the Dream backbone.
  - Upstream `LLaDAConfig` renamed to `LLaDAConfigBase` (mirrors `DreamConfigBase`); `AutoConfig`/`AutoModel` registrations dropped to avoid clashing with the remote-code module in the same process.
  - Optional `position_ids` threaded through `LLaDAModelLM` → `LLaDAModel` → blocks → `RotaryEmbedding` (per-token RoPE positions, e.g. packed cumsum positions); default path is bitwise-unchanged.
  - transformers v5 compatibility: v5 no longer persists None-valued/`use_cache` config kwargs as attributes, so `LLaDAConfigBase.__init__` restores all `ModelConfig` fields explicitly (regression-tested). Note: `DreamConfig` likely has the same latent issue on v5 (e.g. `mask_token_id` silently dropped).
- **Package `xlm-models/llada/`**:
  - `llada_model.py`: `LLaDAXLMModel` MLM-protocol adapter (`forward(x_t, attention_mask, positions) -> logits`), analogue of `DreamXLMModel` — but no `LogitsShiftBy1` (LLaDA predicts masked positions in place) and no 4D mask expansion (backbone handles 2D masks natively).
  - `configuration_llada.py`: `LLaDAConfig(LLaDAConfigBase)` with an explicit `__init__` (required on transformers v5, which otherwise replaces subclass `__init__` with a generated dataclass one).
  - `predictor_llada.py`: `LLaDAPredictor(DreamPredictor)` — Dream's machinery already implements LLaDA's reference sampler (`confidence: top_prob` == `low_confidence` remasking, `block_size` == semi-AR `block_length`); mapping documented in the module docstring.
  - `datamodule_llada.py`: `print_batch_llada` debug helper.
- **Hydra configs `xlm-models/llada/configs/`**: `model/llada_8b.yaml` (one model file serves Base and Instruct; `hub.repo_id` selects the weights), `model_type/llada_base.yaml` + `llada_eval.yaml`, `experiment/math500_llada_eval.yaml` (tokenizer via `load_auto_tokenizer` with `mask_token: <|mdm_mask|>` → id 126336), plus datamodule/collator/debug/fsdp mirrors of Dream's.
- **Registration**: `"llada": "llada"` added to `xlm-models/xlm_models.json`; `llada` added to packages/package_dir/package_data in `xlm-models/setup.py`.
- **Tests `tests/models/llada/`**: 8 CPU tests (forward shape, MLM-protocol signature, position_ids parity, padding-mask effect, HF key layout, strict state-dict roundtrip, config-field roundtrip on v5) + an env-gated full-checkpoint parity test.

## Testing

```bash
# CPU tests (8 passed)
pytest tests/models/llada/test_llada_model.py -q

# Full 8B Hub checkpoint parity vs AutoModel(trust_remote_code=True):
# logits agree at atol/rtol 1e-3 in bf16 (downloads ~16GB; ~9 min on CPU)
XLM_RUN_HUB_TESTS=1 pytest tests/models/llada/test_llada_model.py -k hub

# Hydra composition of the eval experiment through the CLI (verified)
XLM_MODELS_PACKAGES="mlm:dream:llada" xlm job_name=check job_type=evaluate \
  experiment=math500_llada_eval --cfg job
  
  cc @dhruvdcoder @Durga-Prasad1 